### PR TITLE
chore(ci): orphan-fixture check + doc-rot guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,6 @@ jobs:
       - name: Import schema module cleanly
         run: |
           cd poc_v1 && python -c "import sys; sys.path.insert(0, 'ontology'); import schema; print(f'[import] schema v{schema.SCHEMA_VERSION}, {len(schema.NODE_MODELS)} nodes, {len(schema.EDGE_MODELS)} edges')"
+
+      - name: Doc-rot check
+        run: bash scripts/check-doc-rot.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# AGENTS.md — market-ontology
+
+> Short table of contents for agents. The authoritative source for any claim
+> below is the file or command it points to. If a pointer is wrong, fix the
+> pointer — don't edit this file to match stale state.
+
+## What this repo is
+
+The canonical Pydantic schema for the Subconscious knowledge graph:
+**9 node types, 9 edge types**. Installed by sibling repos as
+`pip install "market-ontology @ git+https://github.com/Subconscious-ai/market-ontology"`.
+Load-bearing — every write across the stack validates through here.
+
+## Where things live
+
+| What | Where |
+|---|---|
+| Schema (Pydantic models, NODE_MODELS/EDGE_MODELS) | `poc_v1/ontology/schema.py` |
+| JSON schema dumps for TS/docs consumers | `poc_v1/ontology/{node,edge}_schemas.json` |
+| Reference fixtures (one JSONL per label) | `poc_v1/kg_seed/*.jsonl` |
+| Validator (CI entry point) | `scripts/validate_kg_seed.py` |
+| Doc-rot guard | `scripts/check-doc-rot.sh` |
+| CI workflow | `.github/workflows/ci.yml` |
+| Cross-repo contract | `../ai-chatbot/docs/three-repo-handshake.md` |
+
+## How to verify your work (runs in <30s)
+
+```bash
+python scripts/validate_kg_seed.py        # Pydantic-validates every kg_seed/*.jsonl
+bash scripts/check-doc-rot.sh             # Markdown guard
+python -m py_compile poc_v1/ontology/schema.py   # import-time sanity
+```
+
+If any of these fail, do not open a PR. Fix first.
+
+## How to extend (recipes)
+
+**Add a new node type:**
+1. Add the Pydantic model to `poc_v1/ontology/schema.py`.
+2. Register it in `NODE_MODELS` and bump `SCHEMA_VERSION`.
+3. Create at least one fixture line in `poc_v1/kg_seed/<new_label>s.jsonl`.
+4. Map the filename in `scripts/validate_kg_seed.py::FIXTURES`.
+5. Run the verify loop above.
+
+**Add a new edge type:** same pattern via `EDGE_MODELS` +
+`edges_<from>_<rel>_<to>.jsonl`.
+
+**Rename a field:** breaking change — bump `SCHEMA_VERSION` and coordinate
+with spice-harvester (`lib/emit_kg_seed.py`) and ai-chatbot (graph renderer)
+in the same PR round.
+
+## Architectural invariants (do not break)
+
+- **One source of truth for shape**: Pydantic models in `schema.py`. JSON
+  schema files under `poc_v1/ontology/*.json` are generated artifacts — if
+  they drift, regenerate from the Pydantic models; do not hand-edit.
+- **Fixtures must validate**: `scripts/validate_kg_seed.py` is CI's red button.
+- **No orphan fixtures**: every `kg_seed/*.jsonl` must be mapped in `FIXTURES`.
+- **Node records** are `{"id": ..., "properties": {...}}`. **Edge records**
+  are `{"start_id": ..., "end_id": ..., "properties": {...}}`. Flat is a
+  bug — see `scripts/validate_kg_seed.py` for the payload shape.
+
+## How to ship
+
+- Branch name: `feat/<short>` or `chore/<short>` or `fix/<short>`.
+- Keep PRs focused: schema change + fixture update + validator test is
+  one PR. Do not bundle unrelated fixes.
+- CI must be green before merge. No `--no-verify` unless the user says so.
+- Breaking schema changes get their own PR with a migration note in the
+  body.
+
+## See also
+
+- `CLAUDE.md` — identical content to this file, kept as a Claude Code shim.
+- `../ai-chatbot/docs/three-repo-handshake.md` — how this repo fits into
+  the three-repo stack.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Full path 
   ~/subconscious-ai/
-  ├── spice-harvester/        ← ~/.hermes/clude-harvester/ (still there; move when convenient)
+  ├── spice-harvester/        ← bash + python research pipeline
   │                             github.com/Subconscious-ai/spice-harvester
   │                             • ingest / query / lint / interview / interview-merge
   │                             • docs/INTEGRATION.md ← points at market-ontology

--- a/scripts/check-doc-rot.sh
+++ b/scripts/check-doc-rot.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# scripts/check-doc-rot.sh
+#
+# Fail CI if Markdown docs reference paths that no longer exist. Cheap way to
+# keep CLAUDE.md, READMEs, and plans honest as the three-repo stack evolves.
+#
+# This catches the "stale path" variety of doc rot (most common failure mode
+# in this codebase: README references ~/.hermes/market-intel/, code has moved
+# to ~/subconscious-ai/spice-harvester/). Does NOT catch stale prose or stale
+# command invocations — use human review for those.
+#
+# Checks:
+#   1. Forbidden substrings that mean "this doc is talking about retired code"
+#   2. All ../spice-harvester and ../market-ontology paths referenced in docs
+#      exist relative to the repo root (when those sibling repos are cloned)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+FAIL=0
+
+# 1. Forbidden substrings — updated when retiring a path
+FORBIDDEN=(
+    "~/.hermes/market-intel"
+    "~/.hermes/clude-harvester"
+    "hermes-agent"
+)
+
+for pattern in "${FORBIDDEN[@]}"; do
+    # Skip:
+    # - node_modules / .git (noise)
+    # - archive/ and scar_tissue/ paths (historical record, not live docs)
+    # - agents/market-intel/ (itself a retired, preserved-as-is area)
+    # - this script (which must contain the pattern to search for it)
+    # - any file whose first 3 lines contain `doc-rot-ok` (per-file opt-out
+    #   for migration plans etc. that intentionally describe retired paths)
+    hits=$(grep -rln --include="*.md" \
+        --exclude-dir=node_modules \
+        --exclude-dir=.git \
+        --exclude-dir=archive \
+        --exclude-dir=scar_tissue \
+        --exclude-dir=market-intel \
+        "$pattern" . 2>/dev/null \
+        | grep -v "scripts/check-doc-rot.sh" \
+        || true)
+    # Filter out files with whole-file opt-out
+    filtered=""
+    while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        if head -3 "$f" 2>/dev/null | grep -q "doc-rot-ok"; then
+            continue
+        fi
+        filtered="${filtered}${f}"$'\n'
+    done <<< "$hits"
+    hits="${filtered%$'\n'}"
+    if [ -n "$hits" ]; then
+        # Allow CLAUDE.md to mention the retired path ONCE inside the
+        # explicit "Legacy:" paragraph. Anywhere else → failure.
+        while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            # Count mentions. A mention is OK if the same line also contains
+            # one of the "this is dead" markers below (case-insensitive) —
+            # that means the author is explicitly flagging the path as gone,
+            # not recommending it.
+            total=$(grep -c "$pattern" "$f" || true)
+            markers="legacy|retired|deprecated|deleted|moved|superseded|broken|dead|prior|REWRITE|replaces|removed|formerly|old |gone|archived"
+            legacy=$(grep -cEi "($markers).*$pattern|$pattern.*($markers)" "$f" || true)
+            if [ "$total" -gt "$legacy" ]; then
+                echo "[doc-rot] FORBIDDEN substring '$pattern' in $f ($total mentions, $legacy flagged-as-legacy)"
+                FAIL=1
+            fi
+        done <<< "$hits"
+    fi
+done
+
+# 2. Structural paths we promise exist (check only if sibling repos are cloned)
+if [ -d "../spice-harvester" ]; then
+    for p in "../spice-harvester/run.sh" "../spice-harvester/lib/wiki.py"; do
+        if [ ! -e "$p" ]; then
+            echo "[doc-rot] missing expected sibling path: $p"
+            FAIL=1
+        fi
+    done
+fi
+if [ -d "../market-ontology" ]; then
+    for p in "../market-ontology/scripts/validate_kg_seed.py" "../market-ontology/poc_v1/ontology/schema.py"; do
+        if [ ! -e "$p" ]; then
+            echo "[doc-rot] missing expected sibling path: $p"
+            FAIL=1
+        fi
+    done
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+    echo "[doc-rot] OK"
+fi
+exit $FAIL

--- a/scripts/validate_kg_seed.py
+++ b/scripts/validate_kg_seed.py
@@ -60,6 +60,15 @@ def main() -> int:
     errors: list[str] = []
     checked = 0
 
+    # Catch new fixture files that haven't been mapped to a model yet.
+    on_disk = {p.name for p in KG_SEED_DIR.glob("*.jsonl")}
+    unmapped = sorted(on_disk - set(FIXTURES))
+    if unmapped:
+        errors.append(
+            f"kg_seed/ has unmapped fixture file(s): {unmapped}. "
+            "Add them to FIXTURES in scripts/validate_kg_seed.py."
+        )
+
     for fname, (label, is_edge) in FIXTURES.items():
         path = KG_SEED_DIR / fname
         if not path.exists():


### PR DESCRIPTION
## Summary
- `scripts/validate_kg_seed.py`: catches new `kg_seed/*.jsonl` files that aren't mapped to a model (they could otherwise skip Pydantic validation silently).
- `scripts/check-doc-rot.sh`: Markdown-level guard against references to retired paths (`~/.hermes/market-intel`, `clude-harvester`, `hermes-agent`) without a same-line legacy marker. Per-file opt-out via `<!-- doc-rot-ok -->` in the first three lines.
- CI runs the doc-rot check alongside existing schema + fixture validation.
- README: drop stale pointer to the old `~/.hermes/clude-harvester/` layout.

## Test plan
- [x] `python scripts/validate_kg_seed.py` → `checked 89 records across 19 fixture files — OK`
- [x] `bash scripts/check-doc-rot.sh` → `[doc-rot] OK`
- [x] CI workflow YAML parses
- [ ] GitHub Actions green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)