### PR TITLE
feat(schema): add discovered_via provenance field (1.0.0 → 1.1.0)

### DIFF
--- a/poc_v1/MIGRATION.md
+++ b/poc_v1/MIGRATION.md
@@ -1,6 +1,31 @@
-# Migration — v0 to v1
+# Migration — v0 to v1 (and v1.0 → v1.1)
 
 This document records what changed between the initial POC scaffolding and the v1 ontology, and why. Keep this file. Future schema migrations should follow the same pattern.
+
+## v1.0 → v1.1 (2026-04-22) — add `discovered_via`
+
+**Backwards-compatible.** No fixture rewrites required; existing `kg_seed/*.jsonl` continues to validate.
+
+### Change
+
+Added `discovered_via: Optional[str] = None` to every node type (via `_VersionedNode` mixin) and every edge type (via `_Edge` mixin). Pydantic schema + `node_schemas.json` + `edge_schemas.json` all updated. `SCHEMA_VERSION` bumped `1.0.0 → 1.1.0`.
+
+### Why
+
+The `spice-harvester` pipeline is gaining **deep-research lanes** — Perplexity, Grok, Claude-agent, Gemini-grounded, OpenAI `o1-deep-research`. Each DR provider is a new lane that emits ontology records into `kg_seed/`. We need to tag the records that came from a DR source so the UI can surface "what did deep research unlock vs. the 13 shallow lanes" without re-computing novelty at render time.
+
+### Mechanics for consumers
+
+- **spice-harvester:** writers that originate from a DR lane set `properties.discovered_via = "<provider>"` (e.g. `"perplexity"`). Shallow-lane writers leave it unset.
+- **ai-chatbot:** graph renderer tints nodes with `discovered_via != null`. A filter chip lets operators hide or highlight them.
+- **Neo4j:** no migration needed — optional property, missing values are fine.
+- **Record-level novelty:** the presence of `discovered_via` is **metadata**, not the correctness-critical invariant. Novelty is enforced by id-absence-in-pre-DR-snapshot in `spice-harvester/lib/deep_research/novelty.py` (or wherever the filter lands). Treat `discovered_via` as provenance, not authorization.
+
+### Non-goals
+
+- No `discovered_via` enum — free-form string so new providers can land without schema bumps.
+- No "confidence" or "recency" alongside this field — those are Evidence/Estimate concerns.
+- Does not replace `Evidence.source_type="research_agent"` — Evidence nodes can still represent an individual DR citation; `discovered_via` lives on the ontology node/edge that was synthesized from DR content.
 
 ## Summary
 

--- a/poc_v1/ontology/edge_schemas.json
+++ b/poc_v1/ontology/edge_schemas.json
@@ -1,28 +1,31 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "v1 POC Edge Schemas",
-  "schema_version": "1.0.0",
+  "schema_version": "1.1.0",
   "type": "object",
   "properties": {
     "FROM": {
       "from": "Transition",
       "to": "Stage",
       "properties": {
-        "schema_version": {"type": "string"}
+        "schema_version": {"type": "string"},
+        "discovered_via": {"type": ["string", "null"]}
       }
     },
     "TO": {
       "from": "Transition",
       "to": "Stage",
       "properties": {
-        "schema_version": {"type": "string"}
+        "schema_version": {"type": "string"},
+        "discovered_via": {"type": ["string", "null"]}
       }
     },
     "IN_MARKET": {
       "from": "Transition",
       "to": "Market",
       "properties": {
-        "schema_version": {"type": "string"}
+        "schema_version": {"type": "string"},
+        "discovered_via": {"type": ["string", "null"]}
       }
     },
     "RELEVANT_TO": {
@@ -30,7 +33,8 @@
       "to": "StakeholderArchetype",
       "properties": {
         "confidence": {"type": ["number", "null"], "minimum": 0.0, "maximum": 1.0},
-        "schema_version": {"type": "string"}
+        "schema_version": {"type": "string"},
+        "discovered_via": {"type": ["string", "null"]}
       }
     },
     "ABOUT": {
@@ -38,21 +42,24 @@
       "to": "*",
       "properties": {
         "target_node_type": {"type": ["string", "null"]},
-        "schema_version": {"type": "string"}
+        "schema_version": {"type": "string"},
+        "discovered_via": {"type": ["string", "null"]}
       }
     },
     "HAS_ATTRIBUTE": {
       "from": "Offering",
       "to": "Attribute",
       "properties": {
-        "schema_version": {"type": "string"}
+        "schema_version": {"type": "string"},
+        "discovered_via": {"type": ["string", "null"]}
       }
     },
     "HAS_LEVEL": {
       "from": "Attribute",
       "to": "AttributeLevel",
       "properties": {
-        "schema_version": {"type": "string"}
+        "schema_version": {"type": "string"},
+        "discovered_via": {"type": ["string", "null"]}
       }
     },
     "RELEVANT_AT": {
@@ -63,7 +70,8 @@
         "valid_from": {"type": ["string", "null"], "format": "date"},
         "valid_to": {"type": ["string", "null"], "format": "date"},
         "evidence_ids": {"type": "array", "items": {"type": "string"}},
-        "schema_version": {"type": "string"}
+        "schema_version": {"type": "string"},
+        "discovered_via": {"type": ["string", "null"]}
       }
     },
     "SUPPORTS": {
@@ -73,7 +81,8 @@
         "target_node_type": {"type": ["string", "null"]},
         "confidence": {"type": ["number", "null"], "minimum": 0.0, "maximum": 1.0},
         "support_type": {"type": ["string", "null"]},
-        "schema_version": {"type": "string"}
+        "schema_version": {"type": "string"},
+        "discovered_via": {"type": ["string", "null"]}
       }
     }
   }

--- a/poc_v1/ontology/node_schemas.json
+++ b/poc_v1/ontology/node_schemas.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "v1 POC Node Schemas",
-  "schema_version": "1.0.0",
+  "schema_version": "1.1.0",
   "type": "object",
   "properties": {
     "Market": {
@@ -16,7 +16,8 @@
         "context_factors": {"type": "object"},
         "period": {"type": ["string", "null"]},
         "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "ingested_at": {"type": ["string", "null"], "format": "date-time"},
+        "discovered_via": {"type": ["string", "null"]}
       },
       "additionalProperties": false
     },
@@ -31,7 +32,8 @@
         },
         "definition": {"type": "string"},
         "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "ingested_at": {"type": ["string", "null"], "format": "date-time"},
+        "discovered_via": {"type": ["string", "null"]}
       },
       "additionalProperties": false
     },
@@ -45,7 +47,8 @@
         "to_stage_id": {"type": "string"},
         "definition": {"type": "string"},
         "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "ingested_at": {"type": ["string", "null"], "format": "date-time"},
+        "discovered_via": {"type": ["string", "null"]}
       },
       "additionalProperties": false
     },
@@ -66,7 +69,8 @@
         "company_size_band": {"type": ["string", "null"]},
         "definition": {"type": ["string", "null"]},
         "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "ingested_at": {"type": ["string", "null"], "format": "date-time"},
+        "discovered_via": {"type": ["string", "null"]}
       },
       "additionalProperties": false
     },
@@ -81,7 +85,8 @@
         "category": {"type": ["string", "null"]},
         "definition": {"type": ["string", "null"]},
         "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "ingested_at": {"type": ["string", "null"], "format": "date-time"},
+        "discovered_via": {"type": ["string", "null"]}
       },
       "additionalProperties": false
     },
@@ -98,7 +103,8 @@
         "unit": {"type": ["string", "null"]},
         "definition": {"type": "string"},
         "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "ingested_at": {"type": ["string", "null"], "format": "date-time"},
+        "discovered_via": {"type": ["string", "null"]}
       },
       "additionalProperties": false
     },
@@ -115,7 +121,8 @@
         "valid_from": {"type": ["string", "null"], "format": "date"},
         "valid_to": {"type": ["string", "null"], "format": "date"},
         "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "ingested_at": {"type": ["string", "null"], "format": "date-time"},
+        "discovered_via": {"type": ["string", "null"]}
       },
       "additionalProperties": false
     },
@@ -137,7 +144,8 @@
         "confidence": {"type": ["number", "null"], "minimum": 0.0, "maximum": 1.0},
         "period_observed": {"type": ["string", "null"]},
         "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "ingested_at": {"type": ["string", "null"], "format": "date-time"},
+        "discovered_via": {"type": ["string", "null"]}
       },
       "additionalProperties": false
     },
@@ -169,7 +177,8 @@
         "valid_from": {"type": ["string", "null"], "format": "date"},
         "valid_to": {"type": ["string", "null"], "format": "date"},
         "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "ingested_at": {"type": ["string", "null"], "format": "date-time"},
+        "discovered_via": {"type": ["string", "null"]}
       },
       "additionalProperties": false
     }

--- a/poc_v1/ontology/schema.py
+++ b/poc_v1/ontology/schema.py
@@ -7,7 +7,7 @@ This is the single source of truth for the schema. Keep it aligned with:
   - ontology/edge_schemas.json
   - neo4j/constraints.cypher
 
-Schema version: 1.0.0
+Schema version: 1.1.0
 """
 
 from __future__ import annotations
@@ -18,7 +18,7 @@ from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
-SCHEMA_VERSION = "1.0.0"
+SCHEMA_VERSION = "1.1.0"
 
 
 # ---------------------------------------------------------------------------
@@ -74,6 +74,12 @@ class EstimateType(str, Enum):
 class _VersionedNode(BaseModel):
     schema_version: str = SCHEMA_VERSION
     ingested_at: Optional[datetime] = None
+    # Provenance tag for nodes that came from a deep-research agent lane
+    # (e.g. "perplexity", "grok", "claude_agent") rather than a scrape lane.
+    # None for default-ingest nodes; set on DR-originated nodes by
+    # spice-harvester's novelty filter. UI uses this to tint discovered
+    # nodes; it is metadata, not a correctness-affecting field.
+    discovered_via: Optional[str] = None
 
 
 class _TemporallyValid(BaseModel):
@@ -197,6 +203,10 @@ class _Edge(BaseModel):
     start_id: str
     end_id: str
     schema_version: str = SCHEMA_VERSION
+    # Same deep-research provenance tag as nodes. An edge can be novel
+    # even when both endpoints pre-existed (new relationship discovered
+    # between known entities), so edges need this independently of nodes.
+    discovered_via: Optional[str] = None
 
 
 class EdgeFrom(_Edge):


### PR DESCRIPTION
## What

Adds `Optional[str] discovered_via = None` to every node (via `_VersionedNode`) and every edge (via `_Edge`). Bumps `SCHEMA_VERSION` to `1.1.0`. Updates `node_schemas.json`, `edge_schemas.json`, and `MIGRATION.md` in lockstep.

- `poc_v1/ontology/schema.py` — field + version bump
- `poc_v1/ontology/node_schemas.json` — all 9 nodes
- `poc_v1/ontology/edge_schemas.json` — all 9 edges
- `poc_v1/MIGRATION.md` — new v1.0 → v1.1 section

## Why

Task 1 of the deep-research-lanes plan in spice-harvester — see [`docs/plans/2026-04-22-deep-research-lanes.md`](https://github.com/Subconscious-ai/spice-harvester/blob/main/docs/plans/2026-04-22-deep-research-lanes.md).

spice-harvester is gaining 5 deep-research lanes (Perplexity, Grok, Claude agent, Gemini grounded, OpenAI `o1-deep-research`). Each DR provider is a new lane that emits ontology records. We need to tag records that came from DR so the ai-chatbot UI can surface "what did deep research unlock beyond the 13 shallow lanes."

`discovered_via` is **metadata**, not the correctness-critical invariant. Novelty is enforced by id-absence-in-pre-DR-snapshot in the DR orchestrator. This field is for UI tinting + provenance, nothing else.

## Risk

Backwards-compatible. `Optional[str] = None` means:
- Existing writers don't change.
- Existing fixtures validate without modification (proven below).
- Existing readers that don't know about the field ignore it.

Blast radius: `spice-harvester` + `ai-chatbot` + any future consumers. All consume via the pip package — bumping `SCHEMA_VERSION` surfaces the change without forcing consumers to rewrite.

## Test plan

- [x] `python3 scripts/validate_kg_seed.py` — 89 records × 19 fixtures OK
- [x] `python3 -m py_compile poc_v1/ontology/schema.py` — OK
- [x] `bash scripts/check-doc-rot.sh` — OK
- [x] Round-trip smoke: node + edge each accept `discovered_via` with value and with `None`
- [ ] CI: green on this PR
- [ ] Paired `spice-harvester` PR wires the DR orchestrator to set the field
- [ ] Paired `ai-chatbot` PR tints nodes in the graph renderer when the field is present

## Cross-repo PRs (follow-up, not in this one)

- `spice-harvester`: implements `lib/deep_research/` writing `discovered_via` on DR-originated records
- `ai-chatbot`: updates `components/sizzle/GraphPane*.tsx` to tint nodes with `discovered_via != null`