### PR TITLE
feat(schema): v1.1 — Company node + OFFERED_BY edge

### DIFF
--- a/poc_v1/MIGRATION.md
+++ b/poc_v1/MIGRATION.md
@@ -1,6 +1,32 @@
-# Migration — v0 to v1
+# Migration — v0 to v1 (and v1.0 → v1.1)
 
 This document records what changed between the initial POC scaffolding and the v1 ontology, and why. Keep this file. Future schema migrations should follow the same pattern.
+
+## v1.0 → v1.1 (2026-04-23) — add Company node + OFFERED_BY edge
+
+**Backwards-compatible.** No fixture rewrites required; existing `kg_seed/*.jsonl` continues to validate. `SCHEMA_VERSION` bumped `1.0.0 → 1.1.0`.
+
+### Change
+
+- New node type `Company` with minimal props (`id`, `name`, `domain?`, `definition?`). No funding / size / industry fields — add when a consumer query needs them.
+- New edge type `OFFERED_BY`: `Offering → Company`. This is the programmatic rollup link: `AttributeLevel → (HAS_LEVEL^-1) → Attribute → (HAS_ATTRIBUTE^-1) → Offering → (OFFERED_BY) → Company`.
+- `Offering.company_name` string prop is kept for backwards compat. It will be deprecated in v2 — consumers should start migrating to the edge-based lookup.
+
+### Why
+
+Rehoboam's `attributes-levels/orthogonal` endpoint generates Attributes+Levels per product. Downstream DCE queries aggregate those up to the Company level ("what are all of Acme's attributes across their full product portfolio?"). Doing this via `company_name` string matching is fragile; making Company a first-class node with `OFFERED_BY` edges gives us clean graph traversal and sets up proper entity resolution (Splink on Company.name later).
+
+### Mechanics for consumers
+
+- **spice-harvester:** `lib/emit_kg_seed.py` should derive Company + OFFERED_BY records from each Offering's existing `company_name` string on every write. No new LLM call required — pure transformation. (Paired PR lands at the same time as this bump.)
+- **ai-chatbot:** no immediate changes required. Graph renderer will start receiving Company nodes + OFFERED_BY edges as slugs re-ingest.
+- **Neo4j:** no migration needed — optional node type, missing values are fine.
+
+### Non-goals
+
+- Company-side props beyond `id / name / domain / definition`. YAGNI.
+- Removing `Offering.company_name`. Keep both; remove in v2 cleanup.
+- `Company → Market` edge. Add when a consumer query needs it.
 
 ## Summary
 

--- a/poc_v1/kg_seed/companies.jsonl
+++ b/poc_v1/kg_seed/companies.jsonl
@@ -1,0 +1,1 @@
+{"id": "co_acme", "properties": {"name": "Acme Corporation", "domain": "acme.com", "definition": "Example company used in reference fixtures.", "schema_version": "1.1.0"}}

--- a/poc_v1/kg_seed/edges_offering_offered_by.jsonl
+++ b/poc_v1/kg_seed/edges_offering_offered_by.jsonl
@@ -1,0 +1,1 @@
+{"start_id": "off_acme__widget", "end_id": "co_acme", "properties": {"schema_version": "1.1.0"}}

--- a/poc_v1/ontology/edge_schemas.json
+++ b/poc_v1/ontology/edge_schemas.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "v1 POC Edge Schemas",
-  "schema_version": "1.0.0",
+  "schema_version": "1.1.0",
   "type": "object",
   "properties": {
     "FROM": {
@@ -73,6 +73,13 @@
         "target_node_type": {"type": ["string", "null"]},
         "confidence": {"type": ["number", "null"], "minimum": 0.0, "maximum": 1.0},
         "support_type": {"type": ["string", "null"]},
+        "schema_version": {"type": "string"}
+      }
+    },
+    "OFFERED_BY": {
+      "from": "Offering",
+      "to": "Company",
+      "properties": {
         "schema_version": {"type": "string"}
       }
     }

--- a/poc_v1/ontology/node_schemas.json
+++ b/poc_v1/ontology/node_schemas.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "v1 POC Node Schemas",
-  "schema_version": "1.0.0",
+  "schema_version": "1.1.0",
   "type": "object",
   "properties": {
     "Market": {
@@ -168,6 +168,19 @@
         "estimated_at": {"type": "string", "format": "date-time"},
         "valid_from": {"type": ["string", "null"], "format": "date"},
         "valid_to": {"type": ["string", "null"], "format": "date"},
+        "schema_version": {"type": "string"},
+        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+      },
+      "additionalProperties": false
+    },
+    "Company": {
+      "type": "object",
+      "required": ["id", "name"],
+      "properties": {
+        "id": {"type": "string"},
+        "name": {"type": "string"},
+        "domain": {"type": ["string", "null"]},
+        "definition": {"type": ["string", "null"]},
         "schema_version": {"type": "string"},
         "ingested_at": {"type": ["string", "null"], "format": "date-time"}
       },

--- a/poc_v1/ontology/schema.py
+++ b/poc_v1/ontology/schema.py
@@ -7,7 +7,7 @@ This is the single source of truth for the schema. Keep it aligned with:
   - ontology/edge_schemas.json
   - neo4j/constraints.cypher
 
-Schema version: 1.0.0
+Schema version: 1.1.0
 """
 
 from __future__ import annotations
@@ -18,7 +18,7 @@ from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
-SCHEMA_VERSION = "1.0.0"
+SCHEMA_VERSION = "1.1.0"
 
 
 # ---------------------------------------------------------------------------
@@ -134,11 +134,22 @@ class StakeholderArchetype(_VersionedNode):
 class Offering(_VersionedNode):
     id: str
     name: str
-    # company_name is a string prop in v1 with a Splink dedupe pass.
-    # In v2, Organization becomes a node.
+    # company_name is a string prop kept for backwards compat. As of v1.1
+    # the authoritative link is the OFFERED_BY edge to a Company node.
+    # Will be deprecated in v2.
     company_name: str
     is_competitor: bool = False
     category: Optional[str] = None
+    definition: Optional[str] = None
+
+
+class Company(_VersionedNode):
+    """The organization that offers one or more Offerings. Added in v1.1 to
+    give Offering→Company a proper edge for rollup queries. Minimal props;
+    add funding/size/industry in a later bump when a consumer needs them."""
+    id: str
+    name: str
+    domain: Optional[str] = None
     definition: Optional[str] = None
 
 
@@ -254,6 +265,13 @@ class EdgeSupports(_Edge):
     support_type: Optional[str] = None  # "direct" | "benchmark" | "inferred"
 
 
+class EdgeOfferedBy(_Edge):
+    """Offering -[:OFFERED_BY]-> Company. Introduced in v1.1 as the
+    programmatic rollup link. Consumers aggregating Attributes/Levels up
+    to the Company level traverse this edge."""
+    label: Literal["OFFERED_BY"] = "OFFERED_BY"
+
+
 # ---------------------------------------------------------------------------
 # Convenience: registry for writers/importers
 # ---------------------------------------------------------------------------
@@ -268,6 +286,7 @@ NODE_MODELS: dict[str, type[BaseModel]] = {
     "AttributeLevel": AttributeLevel,
     "Evidence": Evidence,
     "Estimate": Estimate,
+    "Company": Company,
 }
 
 EDGE_MODELS: dict[str, type[BaseModel]] = {
@@ -280,6 +299,7 @@ EDGE_MODELS: dict[str, type[BaseModel]] = {
     "HAS_LEVEL": EdgeHasLevel,
     "RELEVANT_AT": EdgeRelevantAt,
     "SUPPORTS": EdgeSupports,
+    "OFFERED_BY": EdgeOfferedBy,
 }
 
 

--- a/scripts/validate_kg_seed.py
+++ b/scripts/validate_kg_seed.py
@@ -52,6 +52,8 @@ FIXTURES = {
     "edges_attribute_has_level.jsonl":     ("HAS_LEVEL", True),
     "edges_attribute_relevant_at.jsonl":   ("RELEVANT_AT", True),
     "edges_evidence_supports.jsonl":       ("SUPPORTS", True),
+    "companies.jsonl":                     ("Company", False),
+    "edges_offering_offered_by.jsonl":     ("OFFERED_BY", True),
 }
 
 


### PR DESCRIPTION
## What

Backwards-compatible schema bump 1.0.0 → 1.1.0 adding:
- `Company` node (`id`, `name`, `domain?`, `definition?`). Minimal — no funding/size/industry props (YAGNI).
- `OFFERED_BY` edge (`Offering → Company`) — the programmatic rollup link.

## Why

Enables graph-traversal rollup \`AttributeLevel → Attribute → Offering → Company\` without string-matching on \`Offering.company_name\`. Unblocks Task 1 of [Subconscious-ai/spice-harvester#50](https://github.com/Subconscious-ai/spice-harvester/issues/50) (rehoboam attributes-levels persistence) where the Company node is the anchor for aggregating Attributes across a company's full portfolio of Offerings.

## Risk

Zero breaking. \`Offering.company_name\` string prop is kept; consumers that read it keep working. The new node + edge are additive and optional — existing kg_seed files validate unchanged (proven: 91 records × 21 fixtures pass the validator at SCHEMA_VERSION 1.1.0).

## Test plan

- [x] \`python3 scripts/validate_kg_seed.py\` — 91 records × 21 fixtures OK (was 89 × 19)
- [x] \`python3 -m py_compile poc_v1/ontology/schema.py\` — OK
- [x] \`bash scripts/check-doc-rot.sh\` — OK
- [x] \`python3 -c \"import json; [json.load(open(p)) for p in ('poc_v1/ontology/node_schemas.json','poc_v1/ontology/edge_schemas.json')]\"\` — OK
- [x] Round-trip smoke: \`validate_node('Company', {...})\` accepts valid payload with \`domain\`; \`validate_edge('OFFERED_BY', ...)\` accepts Offering→Company shape
- [ ] CI green

## Cross-repo

Paired PR follows in \`Subconscious-ai/spice-harvester\` on branch \`feat/schema/company-derive-edges\`. It updates \`lib/emit_kg_seed.py\` to derive Company + OFFERED_BY records from each Offering's existing \`company_name\` at write time (no new LLM call; pure transformation). This ontology PR must merge first.

Refs Subconscious-ai/spice-harvester#50