### PR TITLE
Publish kg_seed contract artifact

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 ## What this repo is
 
 The canonical Pydantic schema for the Subconscious knowledge graph:
-**9 node types, 9 edge types**. Installed by sibling repos as
+**10 node types, 10 edge types**. Installed by sibling repos as
 `pip install "market-ontology @ git+https://github.com/Subconscious-ai/market-ontology"`.
 Load-bearing — every write across the stack validates through here.
 
@@ -16,7 +16,7 @@ Load-bearing — every write across the stack validates through here.
 | What | Where |
 |---|---|
 | Schema (Pydantic models, NODE_MODELS/EDGE_MODELS) | `poc_v1/ontology/schema.py` |
-| JSON schema dumps for TS/docs consumers | `poc_v1/ontology/{node,edge}_schemas.json` |
+| Generated contracts for consumers | `poc_v1/ontology/{node,edge}_schemas.json`, `poc_v1/ontology/kg_seed_contract.json` |
 | Reference fixtures (one JSONL per label) | `poc_v1/kg_seed/*.jsonl` |
 | Validator (CI entry point) | `scripts/validate_kg_seed.py` |
 | Doc-rot guard | `scripts/check-doc-rot.sh` |
@@ -27,6 +27,7 @@ Load-bearing — every write across the stack validates through here.
 
 ```bash
 python scripts/validate_kg_seed.py        # Pydantic-validates every kg_seed/*.jsonl
+python scripts/generate_kg_seed_contract.py --check  # validates generated consumer contract
 bash scripts/check-doc-rot.sh             # Markdown guard
 python -m py_compile poc_v1/ontology/schema.py   # import-time sanity
 ```
@@ -40,7 +41,8 @@ If any of these fail, do not open a PR. Fix first.
 2. Register it in `NODE_MODELS` and bump `SCHEMA_VERSION`.
 3. Create at least one fixture line in `poc_v1/kg_seed/<new_label>s.jsonl`.
 4. Map the filename in `scripts/validate_kg_seed.py::FIXTURES`.
-5. Run the verify loop above.
+5. Regenerate `poc_v1/ontology/kg_seed_contract.json`.
+6. Run the verify loop above.
 
 **Add a new edge type:** same pattern via `EDGE_MODELS` +
 `edges_<from>_<rel>_<to>.jsonl`.
@@ -52,8 +54,9 @@ in the same PR round.
 ## Architectural invariants (do not break)
 
 - **One source of truth for shape**: Pydantic models in `schema.py`. JSON
-  schema files under `poc_v1/ontology/*.json` are generated artifacts — if
-  they drift, regenerate from the Pydantic models; do not hand-edit.
+  schema files and `kg_seed_contract.json` under `poc_v1/ontology/` are
+  generated artifacts — if they drift, regenerate from the Pydantic models;
+  do not hand-edit.
 - **Fixtures must validate**: `scripts/validate_kg_seed.py` is CI's red button.
 - **No orphan fixtures**: every `kg_seed/*.jsonl` must be mapped in `FIXTURES`.
 - **Node records** are `{"id": ..., "properties": {...}}`. **Edge records**

--- a/poc_v1/ontology/kg_seed_contract.json
+++ b/poc_v1/ontology/kg_seed_contract.json
@@ -1,0 +1,217 @@
+{
+  "schema_version": "1.1.0",
+  "nodes": {
+    "Market": {
+      "filename": "markets.jsonl",
+      "graph_type": "market"
+    },
+    "Stage": {
+      "filename": "stages.jsonl",
+      "graph_type": "stage"
+    },
+    "Transition": {
+      "filename": "transitions.jsonl",
+      "graph_type": "transition"
+    },
+    "StakeholderArchetype": {
+      "filename": "stakeholder_archetypes.jsonl",
+      "graph_type": "stakeholder"
+    },
+    "Offering": {
+      "filename": "offerings.jsonl",
+      "graph_type": "offering"
+    },
+    "Attribute": {
+      "filename": "attributes.jsonl",
+      "graph_type": "attribute"
+    },
+    "AttributeLevel": {
+      "filename": "attribute_levels.jsonl",
+      "graph_type": "attribute_level"
+    },
+    "Evidence": {
+      "filename": "evidence.jsonl",
+      "graph_type": "evidence"
+    },
+    "Estimate": {
+      "filename": "estimates.jsonl",
+      "graph_type": "estimate"
+    },
+    "Company": {
+      "filename": "companies.jsonl",
+      "graph_type": "company"
+    }
+  },
+  "edges": {
+    "FROM": {
+      "filename": "edges_transition_from_stage.jsonl",
+      "filenames": [
+        "edges_transition_from_stage.jsonl"
+      ],
+      "from": "Transition",
+      "to": "Stage"
+    },
+    "TO": {
+      "filename": "edges_transition_to_stage.jsonl",
+      "filenames": [
+        "edges_transition_to_stage.jsonl"
+      ],
+      "from": "Transition",
+      "to": "Stage"
+    },
+    "IN_MARKET": {
+      "filename": "edges_transition_in_market.jsonl",
+      "filenames": [
+        "edges_transition_in_market.jsonl"
+      ],
+      "from": "Transition",
+      "to": "Market"
+    },
+    "RELEVANT_TO": {
+      "filename": "edges_transition_relevant_to.jsonl",
+      "filenames": [
+        "edges_transition_relevant_to.jsonl"
+      ],
+      "from": "Transition",
+      "to": "StakeholderArchetype"
+    },
+    "ABOUT": {
+      "filename": "edges_transition_about_offering.jsonl",
+      "filenames": [
+        "edges_transition_about_offering.jsonl",
+        "edges_estimate_about.jsonl"
+      ],
+      "from": [
+        "Transition",
+        "Estimate"
+      ],
+      "to": "*"
+    },
+    "HAS_ATTRIBUTE": {
+      "filename": "edges_offering_has_attribute.jsonl",
+      "filenames": [
+        "edges_offering_has_attribute.jsonl"
+      ],
+      "from": "Offering",
+      "to": "Attribute"
+    },
+    "HAS_LEVEL": {
+      "filename": "edges_attribute_has_level.jsonl",
+      "filenames": [
+        "edges_attribute_has_level.jsonl"
+      ],
+      "from": "Attribute",
+      "to": "AttributeLevel"
+    },
+    "RELEVANT_AT": {
+      "filename": "edges_attribute_relevant_at.jsonl",
+      "filenames": [
+        "edges_attribute_relevant_at.jsonl"
+      ],
+      "from": "Attribute",
+      "to": "Stage"
+    },
+    "SUPPORTS": {
+      "filename": "edges_evidence_supports.jsonl",
+      "filenames": [
+        "edges_evidence_supports.jsonl"
+      ],
+      "from": "Evidence",
+      "to": "*"
+    },
+    "OFFERED_BY": {
+      "filename": "edges_offering_offered_by.jsonl",
+      "filenames": [
+        "edges_offering_offered_by.jsonl"
+      ],
+      "from": "Offering",
+      "to": "Company"
+    }
+  },
+  "files": {
+    "markets.jsonl": {
+      "kind": "node",
+      "label": "Market"
+    },
+    "stages.jsonl": {
+      "kind": "node",
+      "label": "Stage"
+    },
+    "transitions.jsonl": {
+      "kind": "node",
+      "label": "Transition"
+    },
+    "stakeholder_archetypes.jsonl": {
+      "kind": "node",
+      "label": "StakeholderArchetype"
+    },
+    "offerings.jsonl": {
+      "kind": "node",
+      "label": "Offering"
+    },
+    "attributes.jsonl": {
+      "kind": "node",
+      "label": "Attribute"
+    },
+    "attribute_levels.jsonl": {
+      "kind": "node",
+      "label": "AttributeLevel"
+    },
+    "evidence.jsonl": {
+      "kind": "node",
+      "label": "Evidence"
+    },
+    "estimates.jsonl": {
+      "kind": "node",
+      "label": "Estimate"
+    },
+    "edges_transition_from_stage.jsonl": {
+      "kind": "edge",
+      "label": "FROM"
+    },
+    "edges_transition_to_stage.jsonl": {
+      "kind": "edge",
+      "label": "TO"
+    },
+    "edges_transition_in_market.jsonl": {
+      "kind": "edge",
+      "label": "IN_MARKET"
+    },
+    "edges_transition_relevant_to.jsonl": {
+      "kind": "edge",
+      "label": "RELEVANT_TO"
+    },
+    "edges_transition_about_offering.jsonl": {
+      "kind": "edge",
+      "label": "ABOUT"
+    },
+    "edges_estimate_about.jsonl": {
+      "kind": "edge",
+      "label": "ABOUT"
+    },
+    "edges_offering_has_attribute.jsonl": {
+      "kind": "edge",
+      "label": "HAS_ATTRIBUTE"
+    },
+    "edges_attribute_has_level.jsonl": {
+      "kind": "edge",
+      "label": "HAS_LEVEL"
+    },
+    "edges_attribute_relevant_at.jsonl": {
+      "kind": "edge",
+      "label": "RELEVANT_AT"
+    },
+    "edges_evidence_supports.jsonl": {
+      "kind": "edge",
+      "label": "SUPPORTS"
+    },
+    "companies.jsonl": {
+      "kind": "node",
+      "label": "Company"
+    },
+    "edges_offering_offered_by.jsonl": {
+      "kind": "edge",
+      "label": "OFFERED_BY"
+    }
+  }
+}

--- a/scripts/generate_kg_seed_contract.py
+++ b/scripts/generate_kg_seed_contract.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Generate/check the machine-readable kg_seed contract."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import importlib.util
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).parent.parent
+SCHEMA_PATH = ROOT / "poc_v1" / "ontology" / "schema.py"
+EDGE_SCHEMA_PATH = ROOT / "poc_v1" / "ontology" / "edge_schemas.json"
+CONTRACT_PATH = ROOT / "poc_v1" / "ontology" / "kg_seed_contract.json"
+
+GRAPH_TYPES = {
+    "Market": "market",
+    "Stage": "stage",
+    "Transition": "transition",
+    "StakeholderArchetype": "stakeholder",
+    "Offering": "offering",
+    "Attribute": "attribute",
+    "AttributeLevel": "attribute_level",
+    "Evidence": "evidence",
+    "Estimate": "estimate",
+    "Company": "company",
+}
+
+
+def _load_schema() -> Any:
+    spec = importlib.util.spec_from_file_location("schema", SCHEMA_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["schema"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_fixtures() -> dict[str, tuple[str, bool]]:
+    scripts_dir = str(ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    from validate_kg_seed import FIXTURES
+
+    return FIXTURES
+
+
+def build_contract() -> dict[str, Any]:
+    schema = _load_schema()
+    fixtures = _load_fixtures()
+    edge_schemas = json.loads(EDGE_SCHEMA_PATH.read_text())
+    edge_props = edge_schemas["properties"]
+
+    node_filenames: dict[str, str] = {}
+    edge_filenames: dict[str, list[str]] = defaultdict(list)
+    files: dict[str, dict[str, str]] = {}
+
+    for filename, (label, is_edge) in fixtures.items():
+        kind = "edge" if is_edge else "node"
+        files[filename] = {"kind": kind, "label": label}
+        if is_edge:
+            edge_filenames[label].append(filename)
+        else:
+            node_filenames[label] = filename
+
+    missing_graph_types = sorted(set(schema.NODE_MODELS) - set(GRAPH_TYPES))
+    if missing_graph_types:
+        raise SystemExit(f"GRAPH_TYPES missing node label(s): {missing_graph_types}")
+
+    missing_node_files = sorted(set(schema.NODE_MODELS) - set(node_filenames))
+    if missing_node_files:
+        raise SystemExit(f"FIXTURES missing node file(s): {missing_node_files}")
+
+    missing_edge_files = sorted(set(schema.EDGE_MODELS) - set(edge_filenames))
+    if missing_edge_files:
+        raise SystemExit(f"FIXTURES missing edge file(s): {missing_edge_files}")
+
+    nodes = {
+        label: {
+            "filename": node_filenames[label],
+            "graph_type": GRAPH_TYPES[label],
+        }
+        for label in schema.NODE_MODELS
+    }
+
+    edges = {}
+    for label in schema.EDGE_MODELS:
+        filenames = edge_filenames[label]
+        edge_schema = edge_props[label]
+        edges[label] = {
+            "filename": filenames[0],
+            "filenames": filenames,
+            "from": edge_schema["from"],
+            "to": edge_schema["to"],
+        }
+
+    return {
+        "schema_version": schema.SCHEMA_VERSION,
+        "nodes": nodes,
+        "edges": edges,
+        "files": files,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    text = json.dumps(build_contract(), indent=2) + "\n"
+
+    if args.check:
+        if not CONTRACT_PATH.exists():
+            print(f"{CONTRACT_PATH} is missing", file=sys.stderr)
+            return 1
+        current = CONTRACT_PATH.read_text()
+        if current != text:
+            diff = difflib.unified_diff(
+                current.splitlines(keepends=True),
+                text.splitlines(keepends=True),
+                fromfile=str(CONTRACT_PATH),
+                tofile="generated",
+            )
+            sys.stderr.writelines(diff)
+            return 1
+        print(f"[kg-seed-contract] OK: {CONTRACT_PATH}")
+        return 0
+
+    CONTRACT_PATH.write_text(text)
+    print(f"[kg-seed-contract] wrote {CONTRACT_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Publishes the generated kg_seed contract artifact so spice-harvester and UI consumers can share one machine-readable mapping for filenames, ontology labels, schema version, and graph projection types.

Closes #5.

## What changed

- Adds scripts/generate_kg_seed_contract.py with --check drift detection.
- Adds poc_v1/ontology/kg_seed_contract.json generated from schema and fixture map.
- Documents the contract artifact in AGENTS.md.

## Validation

- python3 scripts/generate_kg_seed_contract.py --check
- python3 scripts/validate_kg_seed.py
- bash scripts/check-doc-rot.sh
