### PR TITLE
fix: make verification checks portable on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/scripts/generate_twenty_app.py
+++ b/scripts/generate_twenty_app.py
@@ -53,7 +53,7 @@ def build_contract() -> dict[str, Any]:
     return {
         "schema_version": manifest["schema_version"],
         "projection_version": manifest["projection_version"],
-        "manifest": str(MANIFEST_PATH.relative_to(ROOT)),
+        "manifest": MANIFEST_PATH.relative_to(ROOT).as_posix(),
         "sync_ledger": manifest["sync_ledger"],
         "objects": objects,
     }

--- a/tests/test_generate_twenty_app.py
+++ b/tests/test_generate_twenty_app.py
@@ -47,6 +47,10 @@ class GenerateTwentyAppTest(unittest.TestCase):
 
         self.assertEqual("1.2.0", contract["schema_version"])
         self.assertEqual("1.0.0", contract["projection_version"])
+        self.assertEqual(
+            "poc_v1/ontology/twenty_projection.json",
+            contract["manifest"],
+        )
         self.assertIn("ontology_node_id", product["fields"])
         self.assertIn("ontology_snapshot_hash", product["fields"])
         self.assertEqual(

--- a/tests/test_repo_portability.py
+++ b/tests/test_repo_portability.py
@@ -1,0 +1,23 @@
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class RepoPortabilityTest(unittest.TestCase):
+    def test_shell_scripts_are_checked_out_with_lf_endings(self):
+        result = subprocess.run(
+            ["git", "check-attr", "eol", "--", "scripts/check-doc-rot.sh"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertIn("eol: lf", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make the Twenty app contract manifest path deterministic across operating systems
- add a regression assertion for the POSIX manifest path
- add `.gitattributes` so shell scripts check out with LF endings, plus a portability test for the doc-rot script

## Root Cause
Windows materialized generated paths with backslashes when `Path.relative_to()` was stringified directly. Separately, shell scripts could check out with CRLF in Windows worktrees, causing Bash to read `pipefail\r`.

## Validation
- `python scripts/validate_kg_seed.py`
- `python scripts/generate_kg_seed_contract.py --check`
- `python scripts/generate_twenty_app.py --check`
- `python -m unittest discover -s tests -v`
- `bash scripts/check-doc-rot.sh`
- `python -m py_compile poc_v1/ontology/schema.py`

Closes #10