### PR TITLE
chore(repo): prune scar tissue across docs and validator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,82 +1,8 @@
 # AGENTS.md — market-ontology
 
-> Short table of contents for agents. The authoritative source for any claim
-> below is the file or command it points to. If a pointer is wrong, fix the
-> pointer — don't edit this file to match stale state.
+The authoritative agent guidance for this repo lives in [`CLAUDE.md`](./CLAUDE.md).
+It covers the verify loop, schema-extension recipes, architectural invariants,
+and how this repo fits into the three-repo Subconscious stack.
 
-## What this repo is
-
-The canonical Pydantic schema for the Subconscious knowledge graph:
-**12 node types, 11 edge types**. Installed by sibling repos as
-`pip install "market-ontology @ git+https://github.com/Subconscious-ai/market-ontology"`.
-Load-bearing — every write across the stack validates through here.
-
-## Where things live
-
-| What | Where |
-|---|---|
-| Schema (Pydantic models, NODE_MODELS/EDGE_MODELS) | `poc_v1/ontology/schema.py` |
-| Generated contracts for consumers | `poc_v1/ontology/{node,edge}_schemas.json`, `poc_v1/ontology/kg_seed_contract.json` |
-| Twenty projection manifest + generated contract | `poc_v1/ontology/twenty_projection.json`, `poc_v1/ontology/twenty_app_contract.json` |
-| Reference fixtures (one JSONL per label) | `poc_v1/kg_seed/*.jsonl` |
-| Validator (CI entry point) | `scripts/validate_kg_seed.py` |
-| Doc-rot guard | `scripts/check-doc-rot.sh` |
-| CI workflow | `.github/workflows/ci.yml` |
-| Cross-repo contract | `../ai-chatbot/docs/three-repo-handshake.md` |
-
-## How to verify your work (runs in <30s)
-
-```bash
-python scripts/validate_kg_seed.py        # Pydantic-validates every kg_seed/*.jsonl
-python scripts/generate_kg_seed_contract.py --check  # validates generated consumer contract
-python scripts/generate_twenty_app.py --check  # validates generated Twenty projection contract
-python -m unittest discover -s tests -v   # projection manifest/generator tests
-bash scripts/check-doc-rot.sh             # Markdown guard
-python -m py_compile poc_v1/ontology/schema.py   # import-time sanity
-```
-
-If any of these fail, do not open a PR. Fix first.
-
-## How to extend (recipes)
-
-**Add a new node type:**
-1. Add the Pydantic model to `poc_v1/ontology/schema.py`.
-2. Register it in `NODE_MODELS` and bump `SCHEMA_VERSION`.
-3. Create at least one fixture line in `poc_v1/kg_seed/<new_label>s.jsonl`.
-4. Map the filename in `scripts/validate_kg_seed.py::FIXTURES`.
-5. Regenerate `poc_v1/ontology/kg_seed_contract.json`.
-6. Run the verify loop above.
-
-**Add a new edge type:** same pattern via `EDGE_MODELS` +
-`edges_<from>_<rel>_<to>.jsonl`.
-
-**Rename a field:** breaking change — bump `SCHEMA_VERSION` and coordinate
-with spice-harvester (`lib/emit_kg_seed.py`) and ai-chatbot (graph renderer)
-in the same PR round.
-
-## Architectural invariants (do not break)
-
-- **One source of truth for shape**: Pydantic models in `schema.py`. JSON
-  schema files and `kg_seed_contract.json` under `poc_v1/ontology/` are
-  generated artifacts — if they drift, regenerate from the Pydantic models;
-  do not hand-edit.
-- **Fixtures must validate**: `scripts/validate_kg_seed.py` is CI's red button.
-- **No orphan fixtures**: every `kg_seed/*.jsonl` must be mapped in `FIXTURES`.
-- **Node records** are `{"id": ..., "properties": {...}}`. **Edge records**
-  are `{"start_id": ..., "end_id": ..., "properties": {...}}`. Flat is a
-  bug — see `scripts/validate_kg_seed.py` for the payload shape.
-
-## How to ship
-
-- Branch name: `feat/<short>` or `chore/<short>` or `fix/<short>`.
-- Keep PRs focused: schema change + fixture update + validator test is
-  one PR. Do not bundle unrelated fixes.
-- CI must be green before merge. No `--no-verify` unless the user says so.
-- Breaking schema changes get their own PR with a migration note in the
-  body.
-
-## See also
-
-- `CLAUDE.md` — identical content to this file, kept as a Claude Code shim.
-- `../ai-chatbot/docs/three-repo-handshake.md` — how this repo fits into
-  the three-repo stack.
+This file exists so the Codex harness (which looks for `AGENTS.md`) lands on
+the same content as the Claude harness — one source of truth, no drift.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,15 @@ One leg of the three-repo Subconscious stack ([spice-harvester](../spice-harvest
 ## Commands
 
 ```bash
-# Pydantic-validate every kg_seed/*.jsonl fixture (CI entry point)
+# Pydantic-validate every kg_seed/*.jsonl fixture (CI red button)
 python scripts/validate_kg_seed.py
+
+# Verify generated consumer contracts are in sync with schema.py (CI gate)
+python scripts/generate_kg_seed_contract.py --check
+python scripts/generate_twenty_app.py --check
+
+# Projection-manifest / portability tests
+python -m unittest discover -s tests -v
 
 # Markdown doc-rot guard (fails on stale paths or forbidden substrings)
 bash scripts/check-doc-rot.sh
@@ -23,6 +30,8 @@ python -m py_compile poc_v1/ontology/schema.py
 # Generated JSON schema sanity
 python -c "import json; [json.load(open(p)) for p in ('poc_v1/ontology/node_schemas.json','poc_v1/ontology/edge_schemas.json')]"
 ```
+
+The full pre-PR loop is the seven commands above; CI in `.github/workflows/ci.yml` runs the same sequence (JSON syntax → kg_seed validation → generated-contract check → projection tests → schema import → doc-rot). If any fail, fix before opening a PR — do not `--no-verify`.
 
 No `pyproject.toml` / `setup.py` / `package.json`. Only runtime dep is Pydantic ≥2.
 
@@ -38,57 +47,72 @@ pip install -e /path/to/market-ontology
 
 ### Schema (the only source of truth)
 
-`poc_v1/ontology/schema.py` defines Pydantic models, `NODE_MODELS` / `EDGE_MODELS` registries, and `SCHEMA_VERSION`.
+`poc_v1/ontology/schema.py` defines Pydantic models, `NODE_MODELS` / `EDGE_MODELS` registries, and `SCHEMA_VERSION` (currently `1.2.0` — bump on every schema change).
 
 **12 node types:** `Market`, `Stage`, `Transition`, `StakeholderArchetype`, `Offering`, `Attribute`, `AttributeLevel`, `Trait`, `TraitLevel`, `Evidence`, `Estimate`, `Company`.
 
-**11 edge types:**
+**Edges (one fixture per type in `poc_v1/kg_seed/edges_*.jsonl`):**
 ```
 Transition -[:FROM]-> Stage
 Transition -[:TO]-> Stage
 Transition -[:IN_MARKET]-> Market
 Transition -[:RELEVANT_TO]-> StakeholderArchetype {confidence}
 Transition -[:ABOUT]-> Offering
-Offering -[:HAS_ATTRIBUTE]-> Attribute
-Attribute/Trait -[:HAS_LEVEL]-> AttributeLevel/TraitLevel
+Offering  -[:HAS_ATTRIBUTE]-> Attribute
+Offering  -[:OFFERED_BY]-> Company                  # added in v1.1
+Attribute -[:HAS_LEVEL]-> AttributeLevel
+Trait     -[:HAS_LEVEL]-> TraitLevel
 StakeholderArchetype -[:HAS_TRAIT]-> Trait
 Attribute -[:RELEVANT_AT {score, valid_from, valid_to, evidence_ids}]-> Stage
-Evidence -[:SUPPORTS]-> * {confidence, support_type}
-Estimate -[:ABOUT]-> * {target_node_type}
+Evidence  -[:SUPPORTS]-> * {confidence, support_type}
+Estimate  -[:ABOUT]-> * {target_node_type}
 ```
+
+The authoritative count is `len(EDGE_MODELS)` in `schema.py` — trust the registry, not this list, if they ever disagree.
 
 Enums live in `poc_v1/ontology/enums.yaml` (StageName, ArchetypeType, AttributeDataType, EvidenceSourceType, EstimateType). Keep `enums.yaml` and `schema.py` in sync by hand — the YAML is human reference, the Python is authoritative.
 
-`node_schemas.json` and `edge_schemas.json` are **generated artifacts**. Regenerate when schema changes; never hand-edit.
+`node_schemas.json`, `edge_schemas.json`, `kg_seed_contract.json`, and `twenty_app_contract.json` are **generated artifacts** consumed by sibling repos. Regenerate when schema changes; never hand-edit. The `--check` flag on the two `generate_*.py` scripts verifies they're in sync without writing.
 
 ### Directory Layout
 
 ```
 poc_v1/
 ├── ontology/
-│   ├── schema.py              ← Pydantic models + NODE_MODELS/EDGE_MODELS + SCHEMA_VERSION (authoritative)
-│   ├── node_schemas.json      ← Generated from schema.py
-│   ├── edge_schemas.json      ← Generated from schema.py
-│   ├── enums.yaml             ← Human reference enums (keep in sync with schema.py)
-│   ├── ontology_spec.md       ← Design doc: 12 nodes, 11 edges, ingestion rules
-│   ├── twenty_projection.json ← Source manifest for Twenty projection
-│   ├── twenty_app_contract.json ← Generated Twenty projection contract
-│   ├── v2_spec.md             ← Parking lot for things cut from v1
-│   └── MIGRATION.md           ← Changes from v0
-├── kg_seed/                   ← Reference fixtures, one JSONL per node/edge label
-│   ├── markets.jsonl, stages.jsonl, transitions.jsonl, ...
-│   └── edges_transition_*.jsonl, edges_estimate_*.jsonl, ...
-├── contracts/                 ← Boundary contracts with Subconscious
+│   ├── schema.py                 ← Pydantic models + NODE_MODELS/EDGE_MODELS + SCHEMA_VERSION (authoritative)
+│   ├── node_schemas.json         ← Generated from schema.py
+│   ├── edge_schemas.json         ← Generated from schema.py
+│   ├── kg_seed_contract.json     ← Generated; consumed by sibling repos as the kg_seed contract
+│   ├── enums.yaml                ← Human reference enums (keep in sync with schema.py)
+│   ├── ontology_spec.md          ← Design doc: 12 nodes, edges, ingestion rules
+│   ├── twenty_projection.json    ← Source manifest for Twenty projection
+│   ├── twenty_projection.md      ← Human-readable Twenty projection spec
+│   ├── twenty_app_contract.json  ← Generated Twenty projection contract
+│   ├── v2_spec.md                ← Parking lot for things cut from v1
+│   └── MIGRATION.md              ← Changes from v0
+├── kg_seed/                      ← Reference fixtures, one JSONL per node/edge label
+│   ├── markets.jsonl, stages.jsonl, transitions.jsonl, companies.jsonl, ...
+│   └── edges_transition_*.jsonl, edges_offering_offered_by.jsonl, edges_estimate_about.jsonl, ...
+├── contracts/                    ← Boundary contracts with Subconscious
 │   ├── experiment_context.schema.json  ← ontology → Subconscious
 │   └── experiment_results.schema.json  ← Subconscious → ontology
 └── neo4j/
     ├── constraints.cypher, import_jsonl.cypher, bloom_search_phrases.cypher
 
 scripts/
-├── validate_kg_seed.py        ← CI: iterates FIXTURES map, Pydantic-validates each JSONL
+├── validate_kg_seed.py           ← CI: iterates FIXTURES map, Pydantic-validates each JSONL
+├── generate_kg_seed_contract.py  ← Regenerates kg_seed_contract.json (--check verifies in-sync)
+├── generate_twenty_app.py        ← Regenerates twenty_app_contract.json (--check verifies in-sync)
 └── check-doc-rot.sh
 
-.github/workflows/ci.yml       ← 4-step: JSON syntax, kg_seed validation, import sanity, doc-rot
+tests/                            ← Projection-manifest + repo-portability unit tests (unittest)
+├── test_generate_twenty_app.py
+├── test_repo_portability.py
+└── test_twenty_projection_manifest.py
+
+.github/workflows/ci.yml          ← 7 steps: setup → JSON syntax → kg_seed validation
+                                    → generated-contract check → projection tests
+                                    → schema import → doc-rot
 ```
 
 ### Write boundary (how kg_seed flows)
@@ -108,16 +132,18 @@ spice-harvester emits `output/<slug>/kg_seed/*.jsonl` via its `lib/emit_kg_seed.
 1. Edit `poc_v1/ontology/schema.py`: add the Pydantic model, register in `NODE_MODELS` or `EDGE_MODELS`, bump `SCHEMA_VERSION`.
 2. Create a matching fixture at `poc_v1/kg_seed/<label>s.jsonl` (or `edges_<label>.jsonl`).
 3. Add the filename → model mapping to `scripts/validate_kg_seed.py::FIXTURES`. Unmapped files fail CI.
-4. Regenerate `node_schemas.json` / `edge_schemas.json` if consumers depend on them.
-5. Run all four commands in the section above. Do not `--no-verify`.
+4. Regenerate consumer contracts: `python scripts/generate_kg_seed_contract.py` and (if the change touches projected fields) `python scripts/generate_twenty_app.py`. Also regenerate `node_schemas.json` / `edge_schemas.json` if consumers depend on them.
+5. Run the full pre-PR loop in the Commands section. Do not `--no-verify`.
 6. Breaking schema changes require coordinated PRs in `spice-harvester` (update `lib/emit_kg_seed.py`) and `ai-chatbot` (update type hints in `app/(chat)/api/interview-sse/` and any graph renderers).
 
-## Conventions (from AGENTS.md)
+## Conventions
 
 - **Branches:** `feat/<short>`, `chore/<short>`, `fix/<short>`.
 - **One concern per PR:** schema change + fixture + validator test = one PR.
 - **No orphan fixtures** — every `kg_seed/*.jsonl` must appear in `FIXTURES`.
 - **Fixtures must validate before opening a PR.**
+
+`AGENTS.md` is a one-line pointer to this file so the Codex harness lands here too. Keep the agent guidance in this file only.
 
 ## Stack (downstream, not implemented here)
 

--- a/README.md
+++ b/README.md
@@ -1,95 +1,91 @@
-Full path 
-  ~/subconscious-ai/
-  ├── spice-harvester/        ← bash + python research pipeline
-  │                             github.com/Subconscious-ai/spice-harvester
-  │                             • ingest / query / lint / interview / interview-merge
-  │                             • docs/INTEGRATION.md ← points at market-ontology
-  │
-  ├── market-ontology/        ← new, at ~/subconscious-ai/market-ontology/
-  │                             github.com/Subconscious-ai/market-ontology
-  │                             • @subconscious-ai/market-ontology (npm)
-  │                             • market-ontology (PyPI when published)
-  │                             • shared source of truth for the POC schema
-  │
-  └── ai-chatbot/             ← your existing Vercel repo; clone here when ready
-                                 depends on @subconscious-ai/market-ontology
-                                 reads spice-harvester's output/<slug>/wiki/
-                                 writes interview answers back via subprocess
+# Market Simulation Ontology — v1 POC
 
-  Everything the ai-chatbot team can now build against
+## Purpose
 
-  1. Shared types — pnpm add @subconscious-ai/market-ontology once published, or local path dep before that.
-  2. Trigger ingest — bash /path/to/spice-harvester/run.sh <email> from an API route.
-  3. Tail progress — SSE off output/<slug>/wiki/log.md (pattern in docs/INTEGRATION.md).
-  4. Read wiki — the 7 category pages + ontology.json for chat context.
-  5. Write interview answers — bash /path/to/spice-harvester/run.sh <email> --interview '{...json...}' per executive turn, then --interview-merge every N answers to upgrade the
-  ontology.
-Market Simulation Ontology — v1 POC
-Purpose
 This package is the minimal ontology that sits between:
 
-A wiki-style market research agent (+ executive interview input)
-The Subconscious.ai discrete choice experiment engine
-The ontology is context for the experiment, not the experiment itself. Subconscious owns experiment design and causal estimation. This repo owns the structured context that feeds Subconscious and the structured results that come back.
+- A wiki-style market research agent (+ executive interview input)
+- The Subconscious.ai discrete choice experiment engine
 
-Scope
-Single customer, single company, 12-month horizon.
-POC-grade. See v2_spec.md for the parking lot of things deliberately cut.
-Core model
+The ontology is **context for the experiment, not the experiment itself.** Subconscious owns experiment design and causal estimation. This repo owns the structured context that feeds Subconscious and the structured results that come back.
+
+## Scope
+
+Single customer, single company, 12-month horizon. POC-grade. See `poc_v1/v2_spec.md` for the parking lot of things deliberately cut.
+
+## Core model
+
 Stakeholder archetypes + Offering attributes + Market context → Transition between AARRR stages → Part-worth estimates back from Subconscious.
 
-Stack
-Neo4j as the store. Bloom for customer-facing visualization.
-Pydantic at the write boundary for schema enforcement.
-Splink (separate job) for entity resolution on Offerings and StakeholderArchetypes.
-APOC for JSONL import/export.
-Postgres + pg_vector (optional, separate) if the research agent needs semantic retrieval over Evidence excerpts.
-Graphiti is deliberately not in v1. Revisit in v2 if research-agent ingestion quality plateaus.
-Node types (12)
-Node	Purpose
-Market	Scope boundary for every query
-Stage	AARRR stage as a first-class node
-Transition	The state change being modeled
-StakeholderArchetype	Customer or competitor-side archetype
-Offering	Object of study (product, service, SKU)
-Attribute	Dimension of an Offering that can be varied
-AttributeLevel	Plausible level for an Attribute in a Market/period
-Trait	Dimension of a StakeholderArchetype used to describe a persona
-TraitLevel	Plausible level for a Trait in a Market/period
-Evidence	Source grounding for any node
-Estimate	Part-worth or other quantity returned from Subconscious
-Company	Organization that offers one or more Offerings
-Edge types (11)
+## Stack
+
+- **Neo4j** as the store. **Bloom** for customer-facing visualization.
+- **Pydantic** at the write boundary for schema enforcement.
+- **Splink** (separate job, in spice-harvester) for entity resolution on Offerings and StakeholderArchetypes.
+- **APOC** for JSONL import/export.
+- **Postgres + pgvector** (optional, separate) if the research agent needs semantic retrieval over Evidence excerpts.
+- **Graphiti** is deliberately not in v1. Revisit in v2 if research-agent ingestion quality plateaus.
+
+## Node types (12)
+
+| Node | Purpose |
+|---|---|
+| Market | Scope boundary for every query |
+| Stage | AARRR stage as a first-class node |
+| Transition | The state change being modeled |
+| StakeholderArchetype | Customer or competitor-side archetype |
+| Offering | Object of study (product, service, SKU) |
+| Attribute | Dimension of an Offering that can be varied |
+| AttributeLevel | Plausible level for an Attribute in a Market/period |
+| Trait | Dimension of a StakeholderArchetype used to describe a persona |
+| TraitLevel | Plausible level for a Trait in a Market/period |
+| Evidence | Source grounding for any node |
+| Estimate | Part-worth or other quantity returned from Subconscious |
+| Company | Organization that offers one or more Offerings |
+
+## Edge types
+
+The authoritative count is `len(EDGE_MODELS)` in `poc_v1/ontology/schema.py`.
+
+```
 Transition -[:FROM]-> Stage
 Transition -[:TO]-> Stage
 Transition -[:IN_MARKET]-> Market
 Transition -[:RELEVANT_TO]-> StakeholderArchetype
 Transition -[:ABOUT]-> Offering
 
-Offering -[:HAS_ATTRIBUTE]-> Attribute
+Offering  -[:HAS_ATTRIBUTE]-> Attribute
+Offering  -[:OFFERED_BY]-> Company
 Attribute -[:HAS_LEVEL]-> AttributeLevel
+Trait     -[:HAS_LEVEL]-> TraitLevel
 StakeholderArchetype -[:HAS_TRAIT]-> Trait
-Trait -[:HAS_LEVEL]-> TraitLevel
 Attribute -[:RELEVANT_AT {score, valid_from, valid_to, evidence_ids}]-> Stage
 
 Evidence -[:SUPPORTS]-> *
 Estimate -[:ABOUT]-> *
-Golden rules
-No probabilities or part-worths on ontology nodes. Those are Estimates. Estimates point at ontology nodes; they don't mutate them.
-Competitor combinations, treatments, and choice tasks live in Subconscious, not here. The ontology provides attributes, levels, archetypes, and context. Subconscious composes experiments.
-If a value is conditional on model, period, or experiment, it is an Estimate.
-Every node has schema_version. Every Estimate has ontology_snapshot_hash.
-Temporal validity (valid_from, valid_to) applies to AttributeLevel, TraitLevel, RELEVANT_AT edges, Estimate, and Evidence. Not to stable definitional nodes (Stage, Market scope, Transition definition).
-Pipeline
-Research agent + executive interview extract node and edge candidates with evidence into JSONL.
-Pydantic validates at the write boundary.
-APOC imports validated JSONL into Neo4j.
-Splink runs entity resolution on Offerings and StakeholderArchetypes after each ingestion pass.
-Customer reviews the graph in Bloom.
-Experiment context is projected to JSON (see contracts/experiment_context.schema.json) and sent to Subconscious.
-Subconscious returns results (see contracts/experiment_results.schema.json) which land as Estimate nodes.
-What changed from v0
-See MIGRATION.md.
+```
 
-What's cut and why
-See v2_spec.md.
+## Golden rules
+
+1. **No probabilities or part-worths on ontology nodes.** Those are `Estimate`s. Estimates point at ontology nodes; they don't mutate them.
+2. **Competitor combinations, treatments, and choice tasks live in Subconscious, not here.** The ontology provides attributes, levels, archetypes, and context. Subconscious composes experiments.
+3. **If a value is conditional on model, period, or experiment, it is an `Estimate`.**
+4. **Every node has `schema_version`. Every `Estimate` has `ontology_snapshot_hash`.**
+5. **Temporal validity** (`valid_from`, `valid_to`) applies to `AttributeLevel`, `TraitLevel`, `RELEVANT_AT` edges, `Estimate`, and `Evidence`. Not to stable definitional nodes (`Stage`, `Market` scope, `Transition` definition).
+
+## Pipeline
+
+1. Research agent + executive interview extract node and edge candidates with evidence into JSONL.
+2. Pydantic validates at the write boundary.
+3. APOC imports validated JSONL into Neo4j.
+4. Splink runs entity resolution on Offerings and StakeholderArchetypes after each ingestion pass.
+5. Customer reviews the graph in Bloom.
+6. Experiment context is projected to JSON (see `poc_v1/contracts/experiment_context.schema.json`) and sent to Subconscious.
+7. Subconscious returns results (see `poc_v1/contracts/experiment_results.schema.json`) which land as `Estimate` nodes.
+
+## See also
+
+- `CLAUDE.md` — agent guidance for Claude Code
+- `AGENTS.md` — agent guidance for Codex
+- `poc_v1/MIGRATION.md` — what changed from v0
+- `poc_v1/v2_spec.md` — what's deliberately cut from v1

--- a/scripts/check-doc-rot.sh
+++ b/scripts/check-doc-rot.sh
@@ -29,18 +29,12 @@ FORBIDDEN=(
 
 for pattern in "${FORBIDDEN[@]}"; do
     # Skip:
-    # - node_modules / .git (noise)
-    # - archive/ and scar_tissue/ paths (historical record, not live docs)
-    # - agents/market-intel/ (itself a retired, preserved-as-is area)
+    # - .git (noise)
     # - this script (which must contain the pattern to search for it)
     # - any file whose first 3 lines contain `doc-rot-ok` (per-file opt-out
     #   for migration plans etc. that intentionally describe retired paths)
     hits=$(grep -rln --include="*.md" \
-        --exclude-dir=node_modules \
         --exclude-dir=.git \
-        --exclude-dir=archive \
-        --exclude-dir=scar_tissue \
-        --exclude-dir=market-intel \
         "$pattern" . 2>/dev/null \
         | grep -v "scripts/check-doc-rot.sh" \
         || true)

--- a/scripts/validate_kg_seed.py
+++ b/scripts/validate_kg_seed.py
@@ -22,12 +22,6 @@ def load_schema():
     mod = importlib.util.module_from_spec(spec)
     sys.modules["schema"] = mod
     spec.loader.exec_module(mod)
-    for reg in (getattr(mod, "NODE_MODELS", {}), getattr(mod, "EDGE_MODELS", {})):
-        for cls in reg.values():
-            try:
-                cls.model_rebuild(_types_namespace={**vars(mod)})
-            except Exception:
-                pass
     return mod.validate_node, mod.validate_edge
 
 


### PR DESCRIPTION
## What
- Drop 26 lines of chat-paste residue from `README.md`; restore markdown structure; fix stale edge count.
- Replace `AGENTS.md` body with a 5-line pointer to `CLAUDE.md` (they had drifted; agent guidance now lives in one place).
- Commit `CLAUDE.md` accuracy fixes (missing `OFFERED_BY` edge, missing pre-PR commands, wrong CI step count, missing files in directory layout).
- Drop dead `--exclude-dir` flags in `scripts/check-doc-rot.sh` (`archive/`, `scar_tissue/`, `market-intel/`, `node_modules` — none exist in this repo).
- Delete `model_rebuild()` try/except block in `scripts/validate_kg_seed.py` (no-op today, swallows future errors).

## Why
Pure cleanup. None of the deletes change behavior — they remove copy-paste residue and dead defensive code. Closes #23 for the audit context.

## Risk
Minimal. No code paths change, no public API touched, no tests modified.

## Test plan
- [x] `python3 scripts/validate_kg_seed.py` — 104 records, 25 fixtures
- [x] `bash scripts/check-doc-rot.sh` — OK
- [x] `python3 scripts/generate_kg_seed_contract.py --check` — OK
- [x] `python3 scripts/generate_twenty_app.py --check` — OK
- [x] `python3 -m unittest discover -s tests -v` — 8 tests, OK
- [ ] CI green

## Follow-up (not in this PR)
#24 — make repo pip-installable + modernize CI (depends on this landing for the CLAUDE.md install section).

Closes #23