### PR TITLE
feat(causal_dag_v1): peer module for causal hypothesis DAGs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,13 @@ jobs:
           python-version: "3.11"
 
       - name: Install runtime deps
-        run: pip install 'pydantic>=2'
+        run: pip install 'pydantic>=2' 'networkx>=3'
+
+      - name: Validate causal_dag_v1 fixtures
+        run: python scripts/validate_causal_dag.py
+
+      - name: Run causal_dag_v1 tests
+        run: python -m unittest tests.test_causal_dag_v1 -v
 
       - name: JSON syntax check (node/edge schemas)
         run: |

--- a/causal_dag_v1/__init__.py
+++ b/causal_dag_v1/__init__.py
@@ -1,0 +1,42 @@
+"""causal_dag_v1 — peer module to poc_v1 for causal hypothesis DAGs.
+
+Today's poc_v1 is a labeled property graph of *types* (Markets, Stages,
+Offerings). Edges express structure (HAS_ATTRIBUTE, FROM, TO).
+**This is not a causal DAG.**
+
+causal_dag_v1 is the peer module that holds the *causal* layer:
+
+    NODES: Cause, Effect, Mediator, Moderator, Confounder, Intervention
+    EDGES: CAUSES (with direction/sign/effect_size/CI), MEDIATES,
+           MODERATES, CONFOUNDED_BY
+
+Lanes feed `poc_v1` (ontology = context). Interview turns and DCE
+outputs feed `causal_dag_v1` (causal hypotheses = result).
+
+NetworkX-based acyclicity check enforces "directed acyclic graph"
+literally — `validate.is_dag(...)` rejects 3-cycles and self-loops.
+
+DoWhy / EconML / CausalNex are downstream consumers, not schema
+definers. This module only provides the Pydantic + NetworkX contract
+layer; the DCE engine binds them as needed.
+"""
+
+from .nodes import (  # noqa: F401
+    Cause,
+    Confounder,
+    Effect,
+    Intervention,
+    Mediator,
+    Moderator,
+    NODE_MODELS,
+)
+from .edges import (  # noqa: F401
+    CAUSES,
+    CONFOUNDED_BY,
+    EDGE_MODELS,
+    MEDIATES,
+    MODERATES,
+)
+from .validate import is_dag, validate_graph  # noqa: F401
+
+CAUSAL_DAG_VERSION = "1.0.0"

--- a/causal_dag_v1/edges.py
+++ b/causal_dag_v1/edges.py
@@ -1,0 +1,85 @@
+"""Pydantic edge models for causal_dag_v1.
+
+Four edge types capturing the causal-graph relationships:
+
+  - CAUSES: directed edge from Cause/Intervention → Effect, with
+    direction (positive / negative), effect size, CI, and intervention
+    semantics (do() vs observe).
+  - MEDIATES: Mediator → Effect, attached to the underlying CAUSES edge.
+  - MODERATES: Moderator → CAUSES edge, modifies effect_size by a factor.
+  - CONFOUNDED_BY: Cause/Effect → Confounder, signals an adjustment need.
+
+Every edge carries the same `start_id` / `end_id` / `properties`
+shape used in poc_v1 for direct interop with the kg_seed JSONL writer.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _CausalEdgeBase(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    start_id: str = Field(..., min_length=1)
+    end_id: str = Field(..., min_length=1)
+    schema_version: str = "1.0.0"
+
+
+class CAUSES(_CausalEdgeBase):
+    """Directed causal edge: start_id (Cause/Intervention) → end_id (Effect/Mediator).
+
+    direction: positive (Cause↑ → Effect↑) or negative (Cause↑ → Effect↓).
+
+    effect_size / ci_low / ci_high: optional. Populated when DCE has
+    estimated the effect. None means "hypothesised but unmeasured."
+
+    intervention: 'do' for experimental (Pearl's do-operator), 'observe'
+    for observational. Mediation analysis assumes 'observe' upstream
+    plus 'do' on the mediator chain.
+    """
+    direction: Literal["pos", "neg"]
+    effect_size: float | None = None
+    ci_low: float | None = None
+    ci_high: float | None = None
+    intervention: Literal["do", "observe"] = "observe"
+    confidence: float = Field(default=0.5, ge=0.0, le=1.0)
+
+
+class MEDIATES(_CausalEdgeBase):
+    """Mediator participates in a causal chain. start_id is the Mediator;
+    end_id is the Effect at the end of the chain. The full chain
+    (Cause → Mediator → Effect) is reconstructed by also looking at the
+    CAUSES edges that connect them.
+    """
+    causes_edge_id: str | None = None  # optional pointer to the CAUSES this mediates
+
+
+class MODERATES(_CausalEdgeBase):
+    """Moderator multiplies / shifts the effect_size of a CAUSES edge.
+
+    start_id is the Moderator. end_id can be either the Effect (shorthand
+    for "moderates the cause→effect path leading here") or a synthetic
+    edge id when the consumer tracks edges as first-class entities.
+    """
+    multiplier: float | None = None
+    shift: float | None = None
+
+
+class CONFOUNDED_BY(_CausalEdgeBase):
+    """Common-cause edge. start_id is Cause OR Effect, end_id is the
+    Confounder. Signals "this Confounder needs to be adjusted for when
+    estimating the causal effect."
+    """
+    adjustment_strategy: Literal[
+        "backdoor", "frontdoor", "iv", "regression", "matching", "other"
+    ] = "backdoor"
+
+
+EDGE_MODELS: dict[str, type[_CausalEdgeBase]] = {
+    "CAUSES": CAUSES,
+    "MEDIATES": MEDIATES,
+    "MODERATES": MODERATES,
+    "CONFOUNDED_BY": CONFOUNDED_BY,
+}

--- a/causal_dag_v1/kg_seed/causes.jsonl
+++ b/causal_dag_v1/kg_seed/causes.jsonl
@@ -1,0 +1,1 @@
+{"id": "cause_perf_per_watt", "properties": {"name": "Power efficiency improvement", "description": "Reduction in W per FLOP for AI training workloads.", "source": "interview", "confidence": 0.7, "manipulable": true}}

--- a/causal_dag_v1/kg_seed/edges_causes.jsonl
+++ b/causal_dag_v1/kg_seed/edges_causes.jsonl
@@ -1,0 +1,1 @@
+{"start_id": "cause_perf_per_watt", "end_id": "effect_dc_adoption", "properties": {"direction": "pos", "effect_size": 0.43, "ci_low": 0.21, "ci_high": 0.65, "intervention": "observe", "confidence": 0.6}}

--- a/causal_dag_v1/kg_seed/effects.jsonl
+++ b/causal_dag_v1/kg_seed/effects.jsonl
@@ -1,0 +1,1 @@
+{"id": "effect_dc_adoption", "properties": {"name": "Data-center NVIDIA adoption rate", "description": "Quarterly net-new GPU racks deployed in hyperscaler DCs.", "source": "interview", "confidence": 0.6, "metric": "racks_per_quarter"}}

--- a/causal_dag_v1/nodes.py
+++ b/causal_dag_v1/nodes.py
@@ -1,0 +1,96 @@
+"""Pydantic node models for causal_dag_v1.
+
+Six node types covering hypothesis-first causal modeling:
+
+  - Cause: an antecedent variable (could be Intervention or just Observed)
+  - Effect: a consequence variable
+  - Mediator: an intermediate causal variable on a Cause→Effect path
+  - Moderator: context that modulates Cause→Effect strength
+  - Confounder: common cause of Cause and Effect needing adjustment
+  - Intervention: a `do()`-style manipulable variable
+
+Every node has a stable `id`, a human-readable `name`, an optional
+`description`, an optional source `evidence_id` (links to a poc_v1
+Evidence node — the cross-module bridge), and a confidence score.
+
+Provenance is enforced at the schema layer: every causal node carries
+`source: Literal["interview", "dce", "expert", "literature"]` so
+consumers can filter / weight by source class.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# Bridge type — Causal nodes can reference Evidence and Estimate ids
+# from poc_v1 (the structural ontology). The string form keeps this
+# module decoupled — no import from poc_v1 needed.
+PocV1Id = str
+
+
+class _CausalNodeBase(BaseModel):
+    """Shared fields for all causal_dag_v1 nodes."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    name: str = Field(..., min_length=1, max_length=240)
+    description: str | None = Field(None, max_length=2000)
+    source: Literal["interview", "dce", "expert", "literature"] = "interview"
+    confidence: float = Field(default=0.5, ge=0.0, le=1.0)
+    evidence_ids: list[PocV1Id] = Field(default_factory=list)
+    schema_version: str = "1.0.0"
+
+
+class Cause(_CausalNodeBase):
+    """An antecedent variable. May be an Intervention (manipulable) or
+    Observed (passive).
+    """
+    manipulable: bool = False
+
+
+class Effect(_CausalNodeBase):
+    """A consequence variable. Can have an attached metric — what would
+    the DCE engine *measure* to estimate this effect?
+    """
+    metric: str | None = Field(None, max_length=120)
+
+
+class Mediator(_CausalNodeBase):
+    """An intermediate causal variable on a Cause → Effect path.
+    Used in mediation analysis (Baron & Kenny, modern direct/indirect
+    effect decomposition).
+    """
+
+
+class Moderator(_CausalNodeBase):
+    """Context that modulates the strength of a Cause → Effect link.
+    Different from Mediator: a moderator sits *outside* the causal chain
+    but changes the chain's coefficient.
+    """
+
+
+class Confounder(_CausalNodeBase):
+    """A common cause of both Cause and Effect. Needs to be adjusted for
+    when estimating the causal effect (backdoor adjustment).
+    """
+
+
+class Intervention(_CausalNodeBase):
+    """A `do()`-style manipulable variable. Distinct from Cause because
+    Intervention is by design controllable in an experiment; Cause is
+    a hypothesis that *could* be intervened on.
+    """
+    intervention_type: Literal["binary", "continuous", "categorical"] = "binary"
+    levels: list[str] = Field(default_factory=list)
+
+
+NODE_MODELS: dict[str, type[_CausalNodeBase]] = {
+    "Cause": Cause,
+    "Effect": Effect,
+    "Mediator": Mediator,
+    "Moderator": Moderator,
+    "Confounder": Confounder,
+    "Intervention": Intervention,
+}

--- a/causal_dag_v1/validate.py
+++ b/causal_dag_v1/validate.py
@@ -1,0 +1,108 @@
+"""NetworkX-based DAG validator for causal_dag_v1.
+
+Two functions:
+
+  - is_dag(graph): True iff the graph is a directed acyclic graph
+    (no cycles, no self-loops). Built on networkx.is_directed_acyclic_graph.
+
+  - validate_graph(graph): Pydantic-validates every node and edge against
+    NODE_MODELS / EDGE_MODELS, then runs is_dag. Returns (errors, ids).
+
+The acyclicity check enforces the "DAG" in causal DAG. Cycles in causal
+hypotheses indicate a modeling error — feedback loops need to be
+unrolled in time (X_t → Y_t → X_{t+1}) or factored through Mediators.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import networkx as nx
+
+from .edges import EDGE_MODELS
+from .nodes import NODE_MODELS
+
+
+def is_dag(graph: dict[str, Any]) -> bool:
+    """True iff the directed graph is acyclic AND has no self-loops.
+
+    `graph` is the canonical {"nodes": {label: [...]}, "edges": {label: [...]}}
+    shape. Only CAUSES and MEDIATES edges contribute to the directed
+    structure (MODERATES and CONFOUNDED_BY are annotations on the
+    causal chain, not part of it).
+    """
+    g = nx.DiGraph()
+    nodes_section = graph.get("nodes") or {}
+    edges_section = graph.get("edges") or {}
+
+    for nodes in nodes_section.values():
+        for n in nodes:
+            nid = n.get("id")
+            if nid:
+                g.add_node(nid)
+
+    for label in ("CAUSES", "MEDIATES"):
+        for e in edges_section.get(label) or []:
+            start = e.get("start_id")
+            end = e.get("end_id")
+            if start and end:
+                if start == end:
+                    return False  # self-loops are not DAGs
+                g.add_edge(start, end)
+
+    return nx.is_directed_acyclic_graph(g)
+
+
+def validate_graph(graph: dict[str, Any]) -> tuple[list[str], dict[str, list[str]]]:
+    """Pydantic-validate every node + edge, then check is_dag.
+
+    Returns (errors, ids):
+      errors: list of human-readable validation failure strings (empty on success)
+      ids: {"nodes": [...], "edges": [...]} — the IDs that validated OK
+    """
+    errors: list[str] = []
+    valid_node_ids: list[str] = []
+    valid_edge_keys: list[str] = []
+
+    nodes_section = graph.get("nodes") or {}
+    edges_section = graph.get("edges") or {}
+
+    for label, rows in nodes_section.items():
+        model = NODE_MODELS.get(label)
+        if model is None:
+            errors.append(f"unknown node label {label!r}")
+            continue
+        for i, row in enumerate(rows):
+            nid = row.get("id")
+            props = row.get("properties") or {}
+            if not nid:
+                errors.append(f"{label}[{i}] missing id")
+                continue
+            try:
+                model.model_validate(props)
+                valid_node_ids.append(nid)
+            except Exception as e:  # noqa: BLE001 — Pydantic raises ValidationError
+                errors.append(f"{label}[{nid}] invalid: {e}")
+
+    for label, rows in edges_section.items():
+        model = EDGE_MODELS.get(label)
+        if model is None:
+            errors.append(f"unknown edge label {label!r}")
+            continue
+        for i, row in enumerate(rows):
+            try:
+                payload = {
+                    "start_id": row.get("start_id"),
+                    "end_id": row.get("end_id"),
+                    **(row.get("properties") or {}),
+                }
+                model.model_validate(payload)
+                valid_edge_keys.append(
+                    f"{label}::{row.get('start_id')}->{row.get('end_id')}"
+                )
+            except Exception as e:  # noqa: BLE001
+                errors.append(f"{label}[{i}] invalid: {e}")
+
+    if not is_dag(graph):
+        errors.append("graph contains a cycle or self-loop in CAUSES/MEDIATES")
+
+    return errors, {"nodes": valid_node_ids, "edges": valid_edge_keys}

--- a/scripts/validate_causal_dag.py
+++ b/scripts/validate_causal_dag.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""CI gate for causal_dag_v1 fixtures.
+
+Reads `causal_dag_v1/kg_seed/*.jsonl`, builds the canonical graph dict,
+runs `causal_dag_v1.validate_graph` (Pydantic + NetworkX acyclicity).
+Exit 1 on any failure.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from causal_dag_v1 import validate_graph  # noqa: E402
+
+
+# Filename → (section, label) — every fixture must be mapped.
+FIXTURES = {
+    "causes.jsonl": ("nodes", "Cause"),
+    "effects.jsonl": ("nodes", "Effect"),
+    "mediators.jsonl": ("nodes", "Mediator"),
+    "moderators.jsonl": ("nodes", "Moderator"),
+    "confounders.jsonl": ("nodes", "Confounder"),
+    "interventions.jsonl": ("nodes", "Intervention"),
+    "edges_causes.jsonl": ("edges", "CAUSES"),
+    "edges_mediates.jsonl": ("edges", "MEDIATES"),
+    "edges_moderates.jsonl": ("edges", "MODERATES"),
+    "edges_confounded_by.jsonl": ("edges", "CONFOUNDED_BY"),
+}
+
+
+def main() -> int:
+    fixtures_dir = REPO_ROOT / "causal_dag_v1" / "kg_seed"
+    if not fixtures_dir.exists():
+        print(f"FAIL: fixtures dir missing: {fixtures_dir}", file=sys.stderr)
+        return 1
+
+    graph: dict = {"nodes": {}, "edges": {}}
+    unmapped: list[str] = []
+
+    for path in sorted(fixtures_dir.iterdir()):
+        if not path.is_file() or path.suffix != ".jsonl":
+            continue
+        mapping = FIXTURES.get(path.name)
+        if mapping is None:
+            unmapped.append(path.name)
+            continue
+        section, label = mapping
+        rows: list[dict] = []
+        for line in path.read_text(errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                print(f"FAIL: {path.name} line: {e}", file=sys.stderr)
+                return 1
+        graph[section].setdefault(label, []).extend(rows)
+
+    if unmapped:
+        print(
+            f"FAIL: unmapped fixtures (add to FIXTURES dict): {unmapped}",
+            file=sys.stderr,
+        )
+        return 1
+
+    errors, ids = validate_graph(graph)
+    if errors:
+        print(f"FAIL: {len(errors)} validation errors:", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+
+    print(
+        f"OK: causal_dag_v1 fixtures valid "
+        f"({len(ids['nodes'])} nodes, {len(ids['edges'])} edges)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_causal_dag_v1.py
+++ b/tests/test_causal_dag_v1.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Tests for causal_dag_v1: schema instantiation, NetworkX acyclicity,
+edge direction validation."""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from causal_dag_v1 import (  # noqa: E402
+    CAUSES,
+    Cause,
+    Confounder,
+    Effect,
+    Intervention,
+    Mediator,
+    Moderator,
+    is_dag,
+    validate_graph,
+)
+
+
+class NodeInstantiationTests(unittest.TestCase):
+    def test_minimum_cause(self):
+        c = Cause(name="x")
+        self.assertEqual(c.name, "x")
+        self.assertEqual(c.source, "interview")
+        self.assertEqual(c.confidence, 0.5)
+        self.assertFalse(c.manipulable)
+
+    def test_effect_with_metric(self):
+        e = Effect(name="adoption", metric="users_per_month")
+        self.assertEqual(e.metric, "users_per_month")
+
+    def test_intervention_levels(self):
+        iv = Intervention(name="discount", intervention_type="categorical",
+                          levels=["0%", "10%", "20%"])
+        self.assertEqual(iv.levels, ["0%", "10%", "20%"])
+
+    def test_extra_fields_rejected(self):
+        with self.assertRaises(Exception):
+            Cause(name="x", bogus_field=42)  # type: ignore[arg-type]
+
+    def test_confidence_out_of_range_rejected(self):
+        with self.assertRaises(Exception):
+            Cause(name="x", confidence=1.5)
+
+
+class EdgeInstantiationTests(unittest.TestCase):
+    def test_causes_minimum(self):
+        e = CAUSES(start_id="c1", end_id="e1", direction="pos")
+        self.assertEqual(e.direction, "pos")
+        self.assertIsNone(e.effect_size)
+        self.assertEqual(e.intervention, "observe")
+
+    def test_causes_with_effect_size(self):
+        e = CAUSES(start_id="c1", end_id="e1", direction="neg",
+                   effect_size=-0.5, ci_low=-0.7, ci_high=-0.3,
+                   intervention="do")
+        self.assertEqual(e.intervention, "do")
+        self.assertEqual(e.effect_size, -0.5)
+
+    def test_invalid_direction_rejected(self):
+        with self.assertRaises(Exception):
+            CAUSES(start_id="c1", end_id="e1", direction="sideways")  # type: ignore[arg-type]
+
+
+class IsDagTests(unittest.TestCase):
+    def test_simple_dag_passes(self):
+        graph = {
+            "nodes": {
+                "Cause": [{"id": "c1"}, {"id": "c2"}],
+                "Effect": [{"id": "e1"}],
+            },
+            "edges": {
+                "CAUSES": [
+                    {"start_id": "c1", "end_id": "e1"},
+                    {"start_id": "c2", "end_id": "e1"},
+                ],
+            },
+        }
+        self.assertTrue(is_dag(graph))
+
+    def test_three_cycle_rejected(self):
+        graph = {
+            "nodes": {"Cause": [{"id": "a"}, {"id": "b"}, {"id": "c"}]},
+            "edges": {
+                "CAUSES": [
+                    {"start_id": "a", "end_id": "b"},
+                    {"start_id": "b", "end_id": "c"},
+                    {"start_id": "c", "end_id": "a"},  # closes the cycle
+                ],
+            },
+        }
+        self.assertFalse(is_dag(graph))
+
+    def test_self_loop_rejected(self):
+        graph = {
+            "nodes": {"Cause": [{"id": "x"}]},
+            "edges": {
+                "CAUSES": [{"start_id": "x", "end_id": "x"}],
+            },
+        }
+        self.assertFalse(is_dag(graph))
+
+    def test_moderates_edges_dont_block_dag(self):
+        # MODERATES is not part of the directed structure — moderator
+        # pointing back at the causal chain shouldn't create a cycle.
+        graph = {
+            "nodes": {
+                "Cause": [{"id": "c1"}],
+                "Effect": [{"id": "e1"}],
+                "Moderator": [{"id": "m1"}],
+            },
+            "edges": {
+                "CAUSES": [{"start_id": "c1", "end_id": "e1"}],
+                "MODERATES": [{"start_id": "m1", "end_id": "e1"}],
+            },
+        }
+        self.assertTrue(is_dag(graph))
+
+
+class ValidateGraphTests(unittest.TestCase):
+    def test_valid_minimal_graph(self):
+        graph = {
+            "nodes": {
+                "Cause": [{"id": "c1", "properties": {"name": "X"}}],
+                "Effect": [{"id": "e1", "properties": {"name": "Y"}}],
+            },
+            "edges": {
+                "CAUSES": [
+                    {"start_id": "c1", "end_id": "e1",
+                     "properties": {"direction": "pos"}},
+                ],
+            },
+        }
+        errors, ids = validate_graph(graph)
+        self.assertEqual(errors, [])
+        self.assertIn("c1", ids["nodes"])
+        self.assertIn("e1", ids["nodes"])
+
+    def test_unknown_node_label_reported(self):
+        graph = {"nodes": {"Mystery": [{"id": "m1", "properties": {"name": "x"}}]}, "edges": {}}
+        errors, _ = validate_graph(graph)
+        self.assertTrue(any("unknown node label" in e for e in errors))
+
+    def test_invalid_node_props_reported(self):
+        graph = {
+            "nodes": {"Cause": [{"id": "c1", "properties": {"name": ""}}]},  # name is min_length=1
+            "edges": {},
+        }
+        errors, _ = validate_graph(graph)
+        self.assertTrue(any("c1" in e for e in errors))
+
+    def test_cycle_reported(self):
+        graph = {
+            "nodes": {
+                "Cause": [{"id": "a", "properties": {"name": "A"}},
+                          {"id": "b", "properties": {"name": "B"}}],
+            },
+            "edges": {
+                "CAUSES": [
+                    {"start_id": "a", "end_id": "b", "properties": {"direction": "pos"}},
+                    {"start_id": "b", "end_id": "a", "properties": {"direction": "pos"}},
+                ],
+            },
+        }
+        errors, _ = validate_graph(graph)
+        self.assertTrue(any("cycle" in e for e in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds `causal_dag_v1/` as a **peer module** to `poc_v1/`. Same pip package, additive only — no `poc_v1` schema changes, no `SCHEMA_VERSION` bump.

## The distinction

Today's `poc_v1` is a labeled property graph of **types** — Markets, Stages, Offerings. Edges express structure (HAS_ATTRIBUTE, FROM, TO). **It is not a causal DAG.**

Subconscious's product mission ("Causal Map of the Human Mind") needs both:

|  | **Ontology** *(`poc_v1`, today)* | **Causal DAG** *(`causal_dag_v1`, NEW)* |
|---|---|---|
| What | Labeled property graph of *types* | Directed acyclic graph of *causal hypotheses* |
| Nodes | Market, Stage, Transition, Offering, Attribute, Evidence, ... | Cause, Effect, Mediator, Moderator, Confounder, Intervention |
| Edges | HAS_ATTRIBUTE, FROM, TO, IN_MARKET (structural / temporal) | CAUSES (direction/sign/effect_size/CI), MEDIATES, MODERATES, CONFOUNDED_BY |
| DAG-ness | Cyclic | Strictly acyclic (NetworkX `is_directed_acyclic_graph`) |
| Source | Lane extractions | Interview turns + DCE outputs |
| Purpose | Context | Result |

## Modules

**`causal_dag_v1/nodes.py`** — 6 Pydantic models. Every node carries `source ∈ {interview, dce, expert, literature}`, `confidence ∈ [0,1]`, optional `evidence_ids` linking to `poc_v1` Evidence nodes (cross-module bridge by string id only — no import coupling).

**`causal_dag_v1/edges.py`** — 4 Pydantic models:
- `CAUSES`: `direction: Literal["pos","neg"]`, `effect_size: float | None`, `ci_low/ci_high`, `intervention: Literal["do","observe"]`
- `MEDIATES`, `MODERATES` (with `multiplier`/`shift`), `CONFOUNDED_BY` (with `adjustment_strategy`)

**`causal_dag_v1/validate.py`** — NetworkX-based:
- `is_dag(graph)`: rejects cycles + self-loops. Only CAUSES + MEDIATES contribute to the directed structure (MODERATES / CONFOUNDED_BY are annotations on the chain).
- `validate_graph(graph)`: Pydantic-validates every node/edge, then `is_dag`. Returns `(errors, ids)`.

## Third-party posture (DoWhy / EconML / CausalNex / NetworkX)

- **NetworkX** — yes, used in the validator. ~300KB pure-Python, added to CI deps.
- **DoWhy** — downstream consumer, not schema definer. The DCE bridge PR (future) will read this module's JSONL and construct DoWhy's `CausalModel`. Don't pull DoWhy into the schema layer.
- **EconML** — downstream estimator. Operates on already-defined DAGs. Not a schema lib.
- **CausalNex** — skipped. We're hypothesis-first (interviews → causal_dag), not data-first / structure-learning. Revisit if/when we ingest large observational datasets.

## CI

```
- pip install 'pydantic>=2' 'networkx>=3'
- python scripts/validate_causal_dag.py   # fixture validator
- python -m unittest tests.test_causal_dag_v1 -v   # 16 tests
```

## Test plan

- [x] `tests/test_causal_dag_v1.py` — 16 tests covering schema instantiation, NetworkX cycle rejection (3-cycle + self-loop), edge direction validation, full-graph validate
- [x] `scripts/validate_causal_dag.py` green: `OK: causal_dag_v1 fixtures valid (2 nodes, 1 edges)`
- [ ] CI green
- [x] `poc_v1` validator + projection tests still green (no `poc_v1` changes)

## Cross-repo

This is **PR 1 of 3** in the causal_dag bundle:
1. **This PR** — schema lands in market-ontology
2. *Next* (spice-harvester) — emit `output/<slug>/causal_dag/*.jsonl` from interview turns + `/causal/<slug>` endpoint
3. *Next* (ai-chatbot) — UI toggle: Ontology | Causal DAG

Merge order: market-ontology → spice-harvester → ai-chatbot.

Closes #28.