### PR TITLE
BEC-1779: Add market-ontology Symphony gate CI

### DIFF
--- a/.github/workflows/symphony-gate.yml
+++ b/.github/workflows/symphony-gate.yml
@@ -1,0 +1,36 @@
+name: Symphony Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  symphony-gate:
+    name: symphony-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.11"
+
+      - name: Install runtime dependencies
+        run: python -m pip install 'pydantic>=2' 'networkx>=3'
+
+      - name: Preflight
+        run: bash scripts/agent/preflight.sh
+
+      - name: Validate fast
+        run: bash scripts/agent/validate-fast.sh

--- a/tests/test_agent_harness_contract.py
+++ b/tests/test_agent_harness_contract.py
@@ -7,6 +7,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 VALIDATE_FAST = ROOT / "scripts" / "agent" / "validate-fast.sh"
 KG_SEED_CONTRACT = ROOT / "poc_v1" / "ontology" / "kg_seed_contract.json"
+SYMPHONY_GATE_WORKFLOW = ROOT / ".github" / "workflows" / "symphony-gate.yml"
 
 
 class AgentHarnessContractTest(unittest.TestCase):
@@ -46,6 +47,32 @@ class AgentHarnessContractTest(unittest.TestCase):
             self.assertIn("kg_seed_contract.json", combined)
         finally:
             KG_SEED_CONTRACT.write_text(original_text)
+
+    def test_symphony_gate_runs_repo_owned_harness_entrypoints(self):
+        workflow = SYMPHONY_GATE_WORKFLOW.read_text()
+
+        self.assertIn("name: Symphony Gate", workflow)
+        self.assertIn("symphony-gate:", workflow)
+        self.assertIn("cancel-in-progress: true", workflow)
+        self.assertIn("permissions:\n  contents: read", workflow)
+        self.assertIn("timeout-minutes: 15", workflow)
+        self.assertIn("bash scripts/agent/preflight.sh", workflow)
+        self.assertIn("bash scripts/agent/validate-fast.sh", workflow)
+
+    def test_symphony_gate_pins_external_github_actions(self):
+        workflow = SYMPHONY_GATE_WORKFLOW.read_text()
+        action_refs = [
+            line.strip().removeprefix("- ").removeprefix("uses: ")
+            for line in workflow.splitlines()
+            if line.strip().startswith("uses: ") or line.strip().startswith("- uses: ")
+        ]
+
+        for action_ref in action_refs:
+            with self.subTest(action_ref=action_ref):
+                if action_ref.startswith("./"):
+                    continue
+                version = action_ref.split("@", 1)[1]
+                self.assertRegex(version, r"^[a-f0-9]{40}$")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add a dedicated Symphony Gate workflow for market-ontology.
- Install deterministic Python runtime dependencies and run the repo-owned agent preflight and validate-fast entrypoints in one CI job.
- Extend the harness contract test to keep the workflow wired to those entrypoints.

## Linear
- https://linear.app/subconscious/issue/BEC-1779/add-market-ontology-symphony-gate-ci

## Validation
- python3 tests/test_agent_harness_contract.py
- bash scripts/agent/preflight.sh && bash scripts/agent/validate-fast.sh

## Scope
CI/harness only. No product behavior changes.