### PR TITLE
docs: add Symphony agent harness guide

### DIFF
--- a/.github/workflows/symphony-gate.yml
+++ b/.github/workflows/symphony-gate.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install runtime dependencies
         run: python -m pip install 'pydantic>=2' 'networkx>=3'
 
+      - name: Readiness
+        run: bash scripts/agent/readiness.sh
+
       - name: Preflight
         run: bash scripts/agent/preflight.sh
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@ Symphony/Codex PRs must use `codex/<issue-id>-<short-slug>` branches, open
 draft PRs, add the `symphony` label, link the Linear issue, and record the
 validation command/result plus check evidence in Linear. Treat schema changes
 as cross-repo contract work and coordinate dependent PRs.
+Exact validation ladder, known secrets, deploy evidence rules, and failure
+buckets live in `docs/agent-harness.md`.
 
 > Short table of contents for agents. The authoritative source for any claim
 > below is the file or command it points to. If a pointer is wrong, fix the

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -1,0 +1,60 @@
+# Agent Harness
+
+This document is the agent-facing contract for Symphony/Codex work in this repo.
+Keep `AGENTS.md` as the map and use this file for operational detail.
+
+## Symphony Readiness Contract
+
+Every Symphony task must end with:
+
+- branch `codex/<linear-issue-id>-<short-slug>`
+- committed local `HEAD`
+- draft GitHub PR that references the Linear issue
+- PR label `symphony`
+- Linear `## Codex Workpad` comment
+- validation command and pass/fail result
+- pushed commit SHA
+- GitHub check URL
+- final Linear state `Human Review` only after `symphony-gate` is green
+
+Failed or incomplete evidence goes to `Rework`, never `Done`.
+
+## Validation Ladder
+
+| Level | Command | Use |
+|---|---|---|
+| Preflight | `bash scripts/agent/preflight.sh` | Python import/dependency readiness before Codex starts |
+| Fast | `bash scripts/agent/validate-fast.sh` | Default Symphony PR gate and normal full deterministic suite |
+| Full | `bash scripts/agent/validate-full.sh` | Same deterministic suite; use for schema/contract changes |
+| Smoke | `bash scripts/agent/smoke.sh` | Alias for fast validation |
+
+Schema changes are cross-repo contract work. Land market-ontology first, then
+coordinate dependent spice-harvester emitters and ai-chatbot consumers.
+
+## Known Secrets
+
+No secrets are required for fast validation. If future validation needs a
+secret, keep it out of `validate-fast.sh` and document the secret here before
+using it.
+
+## Deploy Evidence
+
+This repo does not deploy for normal Symphony PRs. Acceptable evidence:
+
+- `symphony-gate` GitHub check URL
+- CI check URL for schema/fixture validation
+
+## Failure Buckets
+
+Use these exact buckets in workpad blocker notes:
+
+- `preflight`: Python setup/import readiness failed
+- `validation`: schema, generated contract, unit, doc-rot, or compile checks failed
+- `ci_check`: GitHub required check failed
+- `ci_check_timeout`: required check did not finish inside the poll window
+- `git_push`: branch push failed
+- `github_pr`: draft PR creation or lookup failed
+- `github_label`: `symphony` label could not be applied
+- `evidence_gate`: missing workpad, PR, label, validation, SHA, or check evidence
+- `codex_turn`: Codex turn failed or required unavailable human input
+- `token_budget`: Symphony stopped the run for token budget

--- a/docs/agent-observability.md
+++ b/docs/agent-observability.md
@@ -1,0 +1,50 @@
+# Agent Observability
+
+This repo must leave enough evidence for a human or Symphony to understand an
+agent run without replaying the whole conversation.
+
+## Required Run Evidence
+
+Each Symphony PR must expose:
+
+- Linear `## Codex Workpad` with branch, commit SHA, PR URL, validation result,
+  check URL, and blocker notes when applicable
+- draft PR with `symphony` label and Linear issue reference
+- `symphony-gate` GitHub check URL
+- schema/fixture CI check URL
+- local validation command copied verbatim from `scripts/agent/*`
+
+## Where To Look
+
+| Signal | Location |
+|---|---|
+| Agent instructions | `AGENTS.md` |
+| Harness contract | `docs/agent-harness.md` |
+| Readiness check | `bash scripts/agent/readiness.sh` |
+| Fast validation | `bash scripts/agent/validate-fast.sh` |
+| Full validation | `bash scripts/agent/validate-full.sh` |
+| GitHub gate | `.github/workflows/symphony-gate.yml` |
+| Contract smoke | `bash scripts/agent/smoke.sh` |
+
+## Measurement Fields
+
+For canaries and real tasks, record these fields in the Linear workpad or the
+Symphony run trace:
+
+- repo
+- Linear issue
+- branch
+- PR URL
+- validation command
+- validation duration
+- uncached tokens
+- total tokens
+- tool-call count
+- retry count
+- failure bucket
+- final Linear state
+
+## Failure Buckets
+
+Use the buckets from `docs/agent-harness.md`. Do not invent new labels unless
+the harness docs and tests are updated in the same PR.

--- a/scripts/agent/readiness.sh
+++ b/scripts/agent/readiness.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+required_files=(
+  AGENTS.md
+  docs/agent-harness.md
+  docs/agent-observability.md
+  .github/workflows/symphony-gate.yml
+)
+
+for file in "${required_files[@]}"; do
+  test -f "$file" || {
+    echo "missing required harness file: $file" >&2
+    exit 1
+  }
+done
+
+for script in scripts/agent/preflight.sh scripts/agent/validate-fast.sh scripts/agent/validate-full.sh scripts/agent/smoke.sh scripts/agent/readiness.sh; do
+  test -x "$script" || {
+    echo "agent script is not executable: $script" >&2
+    exit 1
+  }
+  grep -q '^set -euo pipefail$' "$script" || {
+    echo "agent script missing bash strict mode: $script" >&2
+    exit 1
+  }
+done
+
+for heading in "Symphony Readiness Contract" "Validation Ladder" "Known Secrets" "Deploy Evidence" "Failure Buckets"; do
+  grep -q "$heading" docs/agent-harness.md || {
+    echo "docs/agent-harness.md missing section: $heading" >&2
+    exit 1
+  }
+done
+
+grep -q "bash scripts/agent/readiness.sh" .github/workflows/symphony-gate.yml || {
+  echo "symphony-gate does not run readiness.sh" >&2
+  exit 1
+}
+
+grep -q "bash scripts/agent/preflight.sh" .github/workflows/symphony-gate.yml
+grep -q "bash scripts/agent/validate-fast.sh" .github/workflows/symphony-gate.yml
+
+echo "agent readiness: ok"

--- a/scripts/agent/validate-fast.sh
+++ b/scripts/agent/validate-fast.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT"
 
+bash scripts/agent/readiness.sh
 python3 scripts/validate_kg_seed.py
 python3 scripts/generate_kg_seed_contract.py --check
 python3 scripts/generate_twenty_app.py --check

--- a/tests/test_agent_harness_contract.py
+++ b/tests/test_agent_harness_contract.py
@@ -14,6 +14,7 @@ class AgentHarnessContractTest(unittest.TestCase):
     def test_validate_fast_includes_deterministic_validation_suite(self):
         text = VALIDATE_FAST.read_text()
         expected_lines = [
+            "bash scripts/agent/readiness.sh",
             "python3 scripts/validate_kg_seed.py",
             "python3 scripts/generate_kg_seed_contract.py --check",
             "python3 scripts/generate_twenty_app.py --check",
@@ -56,6 +57,7 @@ class AgentHarnessContractTest(unittest.TestCase):
         self.assertIn("cancel-in-progress: true", workflow)
         self.assertIn("permissions:\n  contents: read", workflow)
         self.assertIn("timeout-minutes: 15", workflow)
+        self.assertIn("bash scripts/agent/readiness.sh", workflow)
         self.assertIn("bash scripts/agent/preflight.sh", workflow)
         self.assertIn("bash scripts/agent/validate-fast.sh", workflow)
 


### PR DESCRIPTION
## Summary
- add docs/agent-harness.md with Symphony readiness contract
- document validation ladder, known secrets, deploy/check evidence, and failure buckets
- link the guide from AGENTS.md

## Validation
- bash scripts/agent/preflight.sh
- bash scripts/agent/validate-fast.sh