### PR TITLE
Fix causal projection estimator role validation

### DIFF
--- a/poc_v1/contracts/causal_dag_projection.schema.json
+++ b/poc_v1/contracts/causal_dag_projection.schema.json
@@ -27,8 +27,8 @@
       "additionalProperties": false,
       "required": ["transition"],
       "properties": {
-        "transition": {"$ref": "#/$defs/ontology_ref"},
-        "stakeholder_archetype": {"$ref": "#/$defs/ontology_ref"},
+        "transition": {"$ref": "#/$defs/transition_ref"},
+        "stakeholder_archetype": {"$ref": "#/$defs/stakeholder_archetype_ref"},
         "description": {"type": ["string", "null"]}
       }
     },
@@ -46,14 +46,17 @@
         "treatment_variable_ids": {
           "type": "array",
           "minItems": 1,
+          "uniqueItems": true,
           "items": {"type": "string"}
         },
         "effect_modifier_variable_ids": {
           "type": "array",
+          "uniqueItems": true,
           "items": {"type": "string"}
         },
         "control_variable_ids": {
           "type": "array",
+          "uniqueItems": true,
           "items": {"type": "string"}
         }
       }
@@ -99,12 +102,21 @@
         "ExperimentRun"
       ]
     },
-    "ontology_ref": {
+    "transition_ref": {
       "type": "object",
       "additionalProperties": false,
       "required": ["ontology_node_type", "ontology_node_id"],
       "properties": {
-        "ontology_node_type": {"$ref": "#/$defs/ontology_node_type"},
+        "ontology_node_type": {"const": "Transition"},
+        "ontology_node_id": {"type": "string"}
+      }
+    },
+    "stakeholder_archetype_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ontology_node_type", "ontology_node_id"],
+      "properties": {
+        "ontology_node_type": {"const": "StakeholderArchetype"},
         "ontology_node_id": {"type": "string"}
       }
     },

--- a/scripts/validate_causal_projection.py
+++ b/scripts/validate_causal_projection.py
@@ -124,26 +124,69 @@ def _estimation_target_errors(
     errors: list[str] = []
     target = projection.get("estimation_target", {})
 
-    expected_roles = {
-        target.get("outcome_variable_id"): "Y",
-        **{variable_id: "T" for variable_id in target.get("treatment_variable_ids", [])},
-        **{variable_id: "X" for variable_id in target.get("effect_modifier_variable_ids", [])},
-        **{variable_id: "W" for variable_id in target.get("control_variable_ids", [])},
-    }
+    role_groups = [
+        ("Y", [target.get("outcome_variable_id")]),
+        ("T", target.get("treatment_variable_ids") or []),
+        ("X", target.get("effect_modifier_variable_ids") or []),
+        ("W", target.get("control_variable_ids") or []),
+    ]
+    seen_roles: dict[str, str] = {}
 
-    for variable_id, expected_role in expected_roles.items():
-        if not variable_id:
-            continue
-        variable = variables.get(variable_id)
-        if variable is None:
-            errors.append(f"estimation_target unknown variable_id: {variable_id}")
-            continue
-        actual_role = variable.get("estimator_role")
-        if actual_role != expected_role:
-            errors.append(
-                f"estimation_target variable {variable_id} expected estimator_role "
-                f"{expected_role}, found {actual_role}"
-            )
+    for expected_role, variable_ids in role_groups:
+        for variable_id in variable_ids:
+            if not variable_id:
+                continue
+            previous_role = seen_roles.get(variable_id)
+            if previous_role is not None:
+                errors.append(
+                    f"estimation_target variable {variable_id} has multiple estimation roles: "
+                    f"{previous_role} and {expected_role}"
+                )
+                continue
+            seen_roles[variable_id] = expected_role
+
+            variable = variables.get(variable_id)
+            if variable is None:
+                errors.append(f"estimation_target unknown variable_id: {variable_id}")
+                continue
+            actual_role = variable.get("estimator_role")
+            if actual_role != expected_role:
+                errors.append(
+                    f"estimation_target variable {variable_id} expected estimator_role "
+                    f"{expected_role}, found {actual_role}"
+                )
+
+    return errors
+
+
+def _outcome_errors(
+    projection: dict[str, Any],
+    variables: dict[str, dict[str, Any]],
+) -> list[str]:
+    errors: list[str] = []
+    target = projection.get("estimation_target", {})
+    outcome_variable_id = target.get("outcome_variable_id")
+    if not outcome_variable_id:
+        return errors
+
+    outcome_variable = variables.get(outcome_variable_id)
+    if outcome_variable is None:
+        return errors
+
+    transition = (projection.get("outcome") or {}).get("transition") or {}
+    if transition.get("ontology_node_type") not in (None, "Transition"):
+        errors.append("outcome.transition must reference ontology_node_type Transition")
+    if outcome_variable.get("ontology_node_type") != "Transition":
+        errors.append(
+            f"outcome variable {outcome_variable_id} must reference ontology_node_type Transition"
+        )
+        return errors
+
+    transition_id = transition.get("ontology_node_id")
+    if transition_id and outcome_variable.get("ontology_node_id") != transition_id:
+        errors.append(
+            "outcome.transition ontology_node_id must match estimation_target outcome variable"
+        )
 
     return errors
 
@@ -185,6 +228,7 @@ def validate_projection(projection: dict[str, Any]) -> list[str]:
     errors.extend(variable_errors)
     errors.extend(_endpoint_errors(projection, variables))
     errors.extend(_estimation_target_errors(projection, variables))
+    errors.extend(_outcome_errors(projection, variables))
     errors.extend(_time_series_errors(projection))
 
     if not errors:

--- a/tests/test_validate_causal_projection.py
+++ b/tests/test_validate_causal_projection.py
@@ -161,6 +161,46 @@ class ValidateCausalProjectionTest(unittest.TestCase):
 
         self.assertTrue(any("unknown target_variable_id" in error for error in errors))
 
+    def test_rejects_outcome_transition_with_wrong_ontology_type(self):
+        validator = load_validator()
+        projection = valid_projection()
+        projection["outcome"]["transition"]["ontology_node_type"] = "Market"
+
+        errors = validator.validate_projection(projection)
+
+        self.assertTrue(any("Transition" in error for error in errors))
+
+    def test_rejects_outcome_transition_mismatched_with_y_variable(self):
+        validator = load_validator()
+        projection = valid_projection()
+        projection["outcome"]["transition"]["ontology_node_id"] = "tr_other"
+
+        errors = validator.validate_projection(projection)
+
+        self.assertTrue(any("outcome.transition" in error for error in errors))
+
+    def test_rejects_estimation_target_role_collision(self):
+        validator = load_validator()
+        projection = valid_projection()
+        projection["estimation_target"]["treatment_variable_ids"].append(
+            "market_regulatory_pressure"
+        )
+
+        errors = validator.validate_projection(projection)
+
+        self.assertTrue(any("multiple estimation roles" in error for error in errors))
+
+    def test_rejects_duplicate_estimation_target_ids_within_role(self):
+        validator = load_validator()
+        projection = valid_projection()
+        projection["estimation_target"]["treatment_variable_ids"].append(
+            "treatment_provenance_visibility"
+        )
+
+        errors = validator.validate_projection(projection)
+
+        self.assertTrue(any("non-unique elements" in error for error in errors))
+
     def test_rejects_cycles(self):
         validator = load_validator()
         projection = valid_projection()


### PR DESCRIPTION
## Summary
- constrain causal projection outcome refs to Transition and StakeholderArchetype in the contract
- reject estimation target variables reused across Y/T/X/W roles and bind the Y variable to the declared Transition
- add regression coverage for wrong outcome refs, mismatched Y transitions, cross-role collisions, and duplicate IDs

## Verification
- python scripts\\validate_causal_dag.py
- python scripts\\validate_kg_seed.py
- python scripts\\generate_kg_seed_contract.py --check
- python scripts\\generate_twenty_app.py --check
- python scripts\\validate_causal_projection.py poc_v1\\contracts\\examples\\causal_dag_projection.static.valid.json
- python scripts\\validate_causal_projection.py poc_v1\\contracts\\examples\\causal_dag_projection.timeseries.valid.json
- python -m unittest discover -s tests -v
- bash scripts/check-doc-rot.sh
- python -m py_compile poc_v1\\ontology\\schema.py