### PR TITLE
Simplify W&B contract lineage

### DIFF
--- a/poc_v1/contracts/examples/normalized_experiment_results.wandb.valid.json
+++ b/poc_v1/contracts/examples/normalized_experiment_results.wandb.valid.json
@@ -41,11 +41,7 @@
         "row_key": "attribute_id=0;level_ids=2",
         "run_local_attribute_id": 0,
         "run_local_level_id": 2
-      },
-      "subconscious_experiment_id": "e467562c-8b76-451a-9228-d28fbed927e5",
-      "model_version": "hb-amce-importance",
-      "ontology_snapshot_hash": "sha256:telemedicine-demo",
-      "estimated_at": "2026-05-05T14:35:58Z"
+      }
     }
   ]
 }

--- a/poc_v1/contracts/experiment_run_mapping.schema.json
+++ b/poc_v1/contracts/experiment_run_mapping.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Experiment Run Mapping - ontology IDs to SuperEgo/W&B IDs",
-  "description": "Deterministic glue between ontology snapshot IDs and run-local SuperEgo/W&B codebook IDs. Ontology inputs must be declared before run-local IDs are mapped.",
+  "description": "Deterministic glue between ontology snapshot IDs and run-local SuperEgo/W&B codebook IDs. Ontology inputs must be declared before run-local IDs are mapped; mapping keys are derived as source_system:source_field:run_local_id.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -271,7 +271,6 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "mapping_key",
         "source_system",
         "source_field",
         "run_local_id",
@@ -280,11 +279,6 @@
         "role"
       ],
       "properties": {
-        "mapping_key": {
-          "type": "string",
-          "pattern": "^(super_ego|wandb):[^:]+:.+$",
-          "description": "Deterministic key formatted as source_system:source_field:run_local_id."
-        },
         "source_system": {
           "type": "string",
           "enum": ["super_ego", "wandb"]

--- a/poc_v1/contracts/normalized_experiment_results.schema.json
+++ b/poc_v1/contracts/normalized_experiment_results.schema.json
@@ -113,10 +113,6 @@
         "estimate_type",
         "value",
         "about",
-        "subconscious_experiment_id",
-        "model_version",
-        "ontology_snapshot_hash",
-        "estimated_at",
         "source_wandb"
       ],
       "properties": {
@@ -129,10 +125,6 @@
         "ci_low": {"type": ["number", "null"]},
         "ci_high": {"type": ["number", "null"]},
         "standard_error": {"type": ["number", "null"]},
-        "subconscious_experiment_id": {"type": "string"},
-        "model_version": {"type": "string"},
-        "ontology_snapshot_hash": {"type": "string"},
-        "estimated_at": {"type": "string", "format": "date-time"},
         "about": {"$ref": "#/$defs/ontology_ref"},
         "conditioned_on": {
           "type": "array",

--- a/tests/test_causal_projection_contracts.py
+++ b/tests/test_causal_projection_contracts.py
@@ -262,14 +262,13 @@ class CausalProjectionContractsTest(unittest.TestCase):
             projection["artifact_contracts"],
         )
 
-    def test_run_local_ids_map_deterministically_to_ontology_ids(self):
+    def test_run_local_mapping_keys_are_derived_not_stored(self):
         mapping_contract = load_contract("experiment_run_mapping.schema.json")
 
         self.assertIn("ontology_mappings", mapping_contract["required"])
         mapping_def = mapping_contract["$defs"]["ontology_mapping"]
         self.assertCountEqual(
             [
-                "mapping_key",
                 "source_system",
                 "source_field",
                 "run_local_id",
@@ -279,12 +278,14 @@ class CausalProjectionContractsTest(unittest.TestCase):
             ],
             mapping_def["required"],
         )
-        self.assertEqual(
-            "^(super_ego|wandb):[^:]+:.+$",
-            mapping_def["properties"]["mapping_key"]["pattern"],
-        )
+        self.assertNotIn("mapping_key", mapping_def["properties"])
 
-        sample_mappings = [
+        mapping = json.loads(
+            (CONTRACTS_DIR / "examples" / "experiment_run_mapping.wandb.valid.json").read_text(
+                encoding="utf-8",
+            ),
+        )
+        mapping["ontology_mappings"] = [
             {
                 "source_system": "super_ego",
                 "source_field": "target_behavior",
@@ -292,27 +293,13 @@ class CausalProjectionContractsTest(unittest.TestCase):
                 "ontology_node_type": "Transition",
                 "ontology_node_id": "tr_consider_choose",
                 "role": "outcome",
-            },
-            {
-                "source_system": "wandb",
-                "source_field": "analytics_artifact.amce.Features",
-                "run_local_id": "provenance_visibility=high",
-                "ontology_node_type": "AttributeLevel",
-                "ontology_node_id": "attr_level_prov_high",
-                "role": "treatment",
-            },
+            }
         ]
+        self.assertEqual([], list(Draft202012Validator(mapping_contract).iter_errors(mapping)))
 
-        keys = [
-            f"{row['source_system']}:{row['source_field']}:{row['run_local_id']}"
-            for row in sample_mappings
-        ]
-        keys_again = [
-            f"{row['source_system']}:{row['source_field']}:{row['run_local_id']}"
-            for row in sample_mappings
-        ]
-        self.assertEqual(keys, keys_again)
-        self.assertEqual(len(keys), len(set(keys)))
+        row = mapping["ontology_mappings"][0]
+        derived_key = f"{row['source_system']}:{row['source_field']}:{row['run_local_id']}"
+        self.assertEqual("super_ego:target_behavior:dv_001", derived_key)
 
     def test_normalized_amce_wtp_and_importance_become_estimates_about_existing_nodes(self):
         schema = load_schema()
@@ -327,14 +314,17 @@ class CausalProjectionContractsTest(unittest.TestCase):
                 "estimate_type",
                 "value",
                 "about",
-                "subconscious_experiment_id",
-                "model_version",
-                "ontology_snapshot_hash",
-                "estimated_at",
                 "source_wandb",
             ],
             estimate_def["required"],
         )
+        for inherited_field in (
+            "subconscious_experiment_id",
+            "model_version",
+            "ontology_snapshot_hash",
+            "estimated_at",
+        ):
+            self.assertNotIn(inherited_field, estimate_def["properties"])
         self.assertCountEqual(
             [
                 "part_worth",
@@ -358,39 +348,51 @@ class CausalProjectionContractsTest(unittest.TestCase):
                     "estimate_id": "estimate_amce_demo",
                     "estimate_type": "amce",
                     "value": 0.34,
-                    "subconscious_experiment_id": "super-ego-run-1",
-                    "model_version": "hb-amce-importance",
-                    "ontology_snapshot_hash": "sha256:demo",
-                    "estimated_at": "2026-05-04T19:26:21Z",
                     "about": {
                         "ontology_node_type": "AttributeLevel",
                         "ontology_node_id": "attr_level_prov_high",
+                    },
+                    "source_wandb": {
+                        "artifact_name": "amce-demo",
+                        "artifact_type": "analytics",
+                        "artifact_version": "v0",
+                        "artifact_digest": "sha256:fixture",
+                        "file_path": "amce.json",
+                        "row_key": "row-1",
                     },
                 },
                 {
                     "estimate_id": "estimate_wtp_demo",
                     "estimate_type": "wtp",
                     "value": 18000.0,
-                    "subconscious_experiment_id": "super-ego-run-1",
-                    "model_version": "hb-amce-importance",
-                    "ontology_snapshot_hash": "sha256:demo",
-                    "estimated_at": "2026-05-04T19:26:21Z",
                     "about": {
                         "ontology_node_type": "AttributeLevel",
                         "ontology_node_id": "attr_level_prov_high",
+                    },
+                    "source_wandb": {
+                        "artifact_name": "amce-demo",
+                        "artifact_type": "analytics",
+                        "artifact_version": "v0",
+                        "artifact_digest": "sha256:fixture",
+                        "file_path": "amce.json",
+                        "row_key": "row-2",
                     },
                 },
                 {
                     "estimate_id": "estimate_importance_demo",
                     "estimate_type": "importance",
                     "value": 0.42,
-                    "subconscious_experiment_id": "super-ego-run-1",
-                    "model_version": "hb-amce-importance",
-                    "ontology_snapshot_hash": "sha256:demo",
-                    "estimated_at": "2026-05-04T19:26:21Z",
                     "about": {
                         "ontology_node_type": "Transition",
                         "ontology_node_id": "tr_consider_choose",
+                    },
+                    "source_wandb": {
+                        "artifact_name": "importance-demo",
+                        "artifact_type": "analytics",
+                        "artifact_version": "v0",
+                        "artifact_digest": "sha256:fixture",
+                        "file_path": "importance.json",
+                        "row_key": "row-3",
                     },
                 },
             ],

--- a/tests/test_wandb_ontology_loop_contract.py
+++ b/tests/test_wandb_ontology_loop_contract.py
@@ -414,10 +414,6 @@ class WandbOntologyLoopContractTest(unittest.TestCase):
                         "run_local_attribute_id": 0,
                         "run_local_level_id": 2,
                     },
-                    "subconscious_experiment_id": "e467562c-8b76-451a-9228-d28fbed927e5",
-                    "model_version": "hb-amce-importance",
-                    "ontology_snapshot_hash": "sha256:telemedicine-demo",
-                    "estimated_at": "2026-05-05T14:35:58Z",
                 }
             ],
         }
@@ -431,6 +427,18 @@ class WandbOntologyLoopContractTest(unittest.TestCase):
                 "'source_wandb' is a required property" in error
                 for error in validate(
                     missing_wandb_source,
+                    "normalized_experiment_results.schema.json",
+                )
+            )
+        )
+
+        duplicate_lineage = json.loads(json.dumps(normalized))
+        duplicate_lineage["estimates"][0]["ontology_snapshot_hash"] = "sha256:different"
+        self.assertTrue(
+            any(
+                "Additional properties" in error
+                for error in validate(
+                    duplicate_lineage,
                     "normalized_experiment_results.schema.json",
                 )
             )


### PR DESCRIPTION
## Summary
- remove stored mapping_key from ontology mapping rows; consumers derive it from source_system, source_field, and run_local_id
- remove duplicated per-estimate lineage from normalized results; envelope lineage is canonical and materializers copy it into Estimate nodes
- update examples and tests to prove contradictory lineage can no longer be represented

## Verification
- python scripts\\validate_causal_dag.py
- python scripts\\validate_kg_seed.py
- python scripts\\generate_kg_seed_contract.py --check
- python scripts\\generate_twenty_app.py --check
- python scripts\\validate_causal_projection.py poc_v1\\contracts\\examples\\causal_dag_projection.static.valid.json
- python scripts\\validate_causal_projection.py poc_v1\\contracts\\examples\\causal_dag_projection.timeseries.valid.json
- python -m unittest discover -s tests -v
- bash scripts/check-doc-rot.sh
- python -m py_compile poc_v1\\ontology\\schema.py