### PR TITLE
BEC-1805: Symphony setup proof: add tiny harness observability marker

### DIFF
--- a/docs/agent-observability.md
+++ b/docs/agent-observability.md
@@ -44,6 +44,10 @@ Symphony run trace:
 - failure bucket
 - final Linear state
 
+## Static Proof Markers
+
+- BEC-1805: removable Symphony harness observability marker.
+
 ## Failure Buckets
 
 Use the buckets from `docs/agent-harness.md`. Do not invent new labels unless


### PR DESCRIPTION
Refs BEC-1805

Linear: https://linear.app/subconscious/issue/BEC-1805/symphony-setup-proof-add-tiny-harness-observability-marker

This draft PR was published by Symphony after Codex completed the local branch work.
