### PR TITLE
BEC-1825 repair-loop seeded failing PR

### DIFF
--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -3,6 +3,8 @@
 This document is the agent-facing contract for Symphony/Codex work in this repo.
 Keep `AGENTS.md` as the map and use this file for operational detail.
 
+Repair loop proof marker: BEC-1825
+
 ## Symphony Readiness Contract
 
 Every Symphony task must end with:

--- a/tests/test_repair_loop_proof.py
+++ b/tests/test_repair_loop_proof.py
@@ -1,0 +1,21 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class RepairLoopProofTest(unittest.TestCase):
+    def test_agent_harness_docs_record_repair_loop_marker(self):
+        guide = ROOT / "docs" / "agent-harness.md"
+        body = guide.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "Repair loop proof marker: BEC-1825",
+            body,
+            "Repair the seeded CI failure by documenting the BEC-1825 repair loop marker.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs BEC-1825

This draft PR intentionally starts red for the Symphony repair-loop proof.

Seeded failure:
- `tests/test_repair_loop_proof.py` expects `docs/agent-harness.md` to include `Repair loop proof marker: BEC-1825`.
- The marker is intentionally absent in the seed commit.

Expected repair:
- Add the missing marker to `docs/agent-harness.md`.
- Keep the failing test.
- Run `bash scripts/agent/validate-fast.sh`.

Do not merge automatically.
