### PR TITLE
feat(ontology): graphiti_views module — typed view of NODE/EDGE_MODELS

### DIFF
--- a/poc_v1/ontology/graphiti_views.py
+++ b/poc_v1/ontology/graphiti_views.py
@@ -1,0 +1,208 @@
+"""Graphiti-compatible views of the canonical NODE_MODELS / EDGE_MODELS.
+
+graphiti-core 0.29's ``add_episode(entity_types=…, edge_types=…,
+edge_type_map=…)`` requires Pydantic models that:
+
+1. Do not collide with graphiti's reserved EntityNode / EntityEdge field
+   names (``uuid``, ``name``, ``summary``, …) — collision raises
+   ``EntityTypeValidationError`` at extraction time.
+2. Have no ``Any``-typed fields — OpenAI's structured-output API rejects
+   schemas without a concrete ``type`` key, surfacing as an
+   ``add_episode`` failure.
+
+This module derives the graphiti view from the canonical schema at
+import time. The canonical Pydantic models in ``schema.py`` stay
+unchanged — view-models are graphiti-only.
+
+It also builds ``EDGE_TYPE_MAP`` (``dict[(source_label, target_label),
+list[predicates]]``) by expanding ``kg_seed_contract.json::edges``.
+``from``/``to`` may be a string, a list, or ``"*"`` (wildcard) — the
+expander turns all three into concrete ``(from, to)`` cells with the
+edge label appended.
+
+Why this lives in market-ontology rather than each consumer:
+
+The graphiti view is a property of the schema (which fields are
+exposed for typed extraction), not of any particular consumer. Keeping
+it next to the schema means:
+
+- The reserved-field stripping logic stays in lock-step with the
+  Pydantic models — adding a new node automatically gets a graphiti
+  view, no consumer-side changes needed.
+- New consumers (twenty CRM projection, causl.io agent, future research
+  bots) import a ready-made view instead of re-deriving it.
+- Drift between the contract (``kg_seed_contract.json``) and the model
+  registry surfaces at import time in this module rather than at
+  add_episode time in production.
+
+Public API:
+    ENTITY_TYPES: dict[str, type[BaseModel]]
+    EDGE_TYPES:   dict[str, type[BaseModel]]
+    EDGE_TYPE_MAP: dict[tuple[str, str], list[str]]
+    SCHEMA_VERSION: str
+"""
+from __future__ import annotations
+
+import json
+from itertools import product
+from pathlib import Path
+from typing import Any, get_args
+
+from pydantic import BaseModel, create_model
+
+from . import schema as _schema
+
+# Field names graphiti-core 0.29 has on its own EntityNode / EntityEdge.
+# Custom entity_types / edge_types whose Pydantic fields overlap with
+# these will raise EntityTypeValidationError on add_episode (see
+# graphiti_core/utils/ontology_utils/entity_types_utils.py:23-37).
+# Verified against graphiti-core 0.29; bump these on upgrade.
+_GRAPHITI_NODE_RESERVED = frozenset({
+    "uuid", "name", "group_id", "labels", "created_at",
+    "name_embedding", "summary", "attributes",
+})
+_GRAPHITI_EDGE_RESERVED = frozenset({
+    "uuid", "group_id", "source_node_uuid", "target_node_uuid",
+    "created_at", "name", "fact", "fact_embedding", "episodes",
+    "expired_at", "valid_at", "invalid_at", "reference_time",
+    "attributes",
+})
+
+
+def _annotation_uses_any(annotation: object) -> bool:
+    """True if the annotation is ``Any`` or has ``Any`` as a parameter
+    (e.g. ``dict[str, Any]``).
+
+    OpenAI's structured-output API requires every field to have a
+    concrete JSON schema type, so ``Any``-typed fields trip the LLM with
+    ``Invalid schema for response_format X: properties.<field>, schema
+    must have a "type" key``. Graphiti surfaces that error as an
+    add_episode failure — we drop these fields from the view models
+    before passing to entity_types.
+    """
+    if annotation is Any:
+        return True
+    args = get_args(annotation)
+    return any(a is Any for a in args)
+
+
+def _strip_reserved(
+    canonical: type[BaseModel], reserved: frozenset[str]
+) -> type[BaseModel]:
+    """Build a graphiti-compatible view of an ontology Pydantic model.
+
+    Drops two kinds of fields:
+    1. Names that collide with graphiti-core's reserved Entity / Edge
+       attributes (``name``, ``summary``, …).
+    2. Fields whose annotation includes ``Any`` (see ``_annotation_uses_any``).
+
+    Every other field — including its ``Field(...)`` default and
+    description — is preserved so the LLM still extracts what we care
+    about. Canonical Pydantic models in ``schema.py`` stay unchanged.
+    """
+    fields = {}
+    for field_name, field_info in canonical.model_fields.items():
+        if field_name in reserved:
+            continue
+        if _annotation_uses_any(field_info.annotation):
+            continue
+        fields[field_name] = (field_info.annotation, field_info)
+    new_cls = create_model(
+        canonical.__name__,
+        __doc__=canonical.__doc__,
+        **fields,
+    )
+    new_cls.__module__ = __name__
+    return new_cls
+
+
+ENTITY_TYPES: dict[str, type[BaseModel]] = {
+    label: _strip_reserved(model, _GRAPHITI_NODE_RESERVED)
+    for label, model in _schema.NODE_MODELS.items()
+}
+EDGE_TYPES: dict[str, type[BaseModel]] = {
+    label: _strip_reserved(model, _GRAPHITI_EDGE_RESERVED)
+    for label, model in _schema.EDGE_MODELS.items()
+}
+
+
+def _load_contract() -> dict:
+    """Read kg_seed_contract.json from the installed schema package."""
+    contract_path = Path(_schema.__file__).parent / "kg_seed_contract.json"
+    with contract_path.open() as f:
+        return json.load(f)
+
+
+def _expand_endpoints(endpoint: object, all_node_labels: set[str]) -> list[str]:
+    """Turn a contract ``from``/``to`` value into a concrete label list.
+
+    Three accepted shapes:
+    - ``"Transition"`` (single label)
+    - ``["Transition", "Estimate"]`` (list of labels)
+    - ``"*"`` (wildcard — every canonical node)
+    """
+    if isinstance(endpoint, str):
+        if endpoint == "*":
+            return sorted(all_node_labels)
+        return [endpoint]
+    if isinstance(endpoint, list):
+        return list(endpoint)
+    raise TypeError(
+        f"unexpected endpoint shape in kg_seed_contract.json: {endpoint!r}"
+    )
+
+
+def _build_edge_type_map(contract: dict) -> dict[tuple[str, str], list[str]]:
+    """Cartesian-product the contract's edges into Graphiti's edge_type_map.
+
+    For each edge label, expand ``from`` and ``to`` to concrete node-label
+    lists and add the predicate to every ``(from, to)`` cell. Predicates
+    dedupe within a cell so polymorphic edges (``HAS_LEVEL`` via
+    Attribute/Trait) don't double-register.
+    """
+    all_nodes = set(contract["nodes"].keys())
+    out: dict[tuple[str, str], list[str]] = {}
+    for label, spec in contract["edges"].items():
+        from_labels = _expand_endpoints(spec["from"], all_nodes)
+        to_labels = _expand_endpoints(spec["to"], all_nodes)
+        for f, t in product(from_labels, to_labels):
+            cell = out.setdefault((f, t), [])
+            if label not in cell:
+                cell.append(label)
+    return out
+
+
+_CONTRACT = _load_contract()
+EDGE_TYPE_MAP: dict[tuple[str, str], list[str]] = _build_edge_type_map(_CONTRACT)
+
+
+# Import-time invariant: the contract's node/edge sets must match the
+# Pydantic registry. Drift means somebody updated one and not the other —
+# regenerate the contract with `python scripts/generate_kg_seed_contract.py`
+# and bump SCHEMA_VERSION.
+_contract_nodes = set(_CONTRACT["nodes"].keys())
+_ontology_nodes = set(ENTITY_TYPES.keys())
+if _contract_nodes != _ontology_nodes:
+    raise RuntimeError(
+        "kg_seed_contract.json drift: "
+        f"contract={_contract_nodes} vs ontology={_ontology_nodes}; "
+        "regenerate the contract and bump SCHEMA_VERSION."
+    )
+
+_contract_edges = set(_CONTRACT["edges"].keys())
+_ontology_edges = set(EDGE_TYPES.keys())
+if _contract_edges != _ontology_edges:
+    raise RuntimeError(
+        "kg_seed_contract.json drift: "
+        f"contract={_contract_edges} vs ontology={_ontology_edges}; "
+        "regenerate the contract and bump SCHEMA_VERSION."
+    )
+
+SCHEMA_VERSION = _schema.SCHEMA_VERSION
+
+__all__ = [
+    "ENTITY_TYPES",
+    "EDGE_TYPES",
+    "EDGE_TYPE_MAP",
+    "SCHEMA_VERSION",
+]

--- a/tests/test_graphiti_views.py
+++ b/tests/test_graphiti_views.py
@@ -1,0 +1,239 @@
+"""Contract + invariant tests for poc_v1.ontology.graphiti_views.
+
+The module under test derives Graphiti-compatible Pydantic view-models
+from the canonical NODE_MODELS / EDGE_MODELS in schema.py. It also
+builds an EDGE_TYPE_MAP keyed by (source_label, target_label) — what
+Graphiti.add_episode(edge_type_map=…) needs.
+
+These tests live alongside the schema so that any consumer (sidecar,
+twenty CRM, future agents) can rely on the contract without re-deriving
+the view themselves.
+"""
+from __future__ import annotations
+
+import unittest
+
+from pydantic import BaseModel
+
+
+class TestEntityTypesAreCanonicalOntology(unittest.TestCase):
+    """ENTITY_TYPES is derived from NODE_MODELS, no hand-rolled copies."""
+
+    def test_loads_from_schema(self):
+        from poc_v1.ontology.graphiti_views import ENTITY_TYPES
+
+        self.assertGreater(len(ENTITY_TYPES), 0)
+        for label, model in ENTITY_TYPES.items():
+            self.assertIsInstance(label, str)
+            self.assertTrue(issubclass(model, BaseModel))
+
+    def test_contains_expected_canonical_nodes(self):
+        from poc_v1.ontology.graphiti_views import ENTITY_TYPES
+
+        # Canon as of 1.2.0; if a future schema drops one, this catches it.
+        expected = {
+            "Market", "Stage", "Transition", "StakeholderArchetype",
+            "Offering", "Attribute", "AttributeLevel", "Trait", "TraitLevel",
+            "Evidence", "Estimate", "Company",
+        }
+        self.assertEqual(set(ENTITY_TYPES) & expected, expected)
+
+    def test_every_node_has_contract_entry(self):
+        """Schema-bump-resilient invariant: every NODE_MODELS entry must
+        also appear in kg_seed_contract.json's `nodes` map. Catches drift
+        where someone adds a model but forgets to regenerate the contract."""
+        from poc_v1.ontology.graphiti_views import ENTITY_TYPES, _CONTRACT
+
+        contract_nodes = set(_CONTRACT["nodes"].keys())
+        ontology_nodes = set(ENTITY_TYPES.keys())
+        self.assertEqual(
+            ontology_nodes, contract_nodes,
+            f"drift: extra in ontology={ontology_nodes - contract_nodes}, "
+            f"extra in contract={contract_nodes - ontology_nodes}",
+        )
+
+
+class TestEdgeTypesAreCanonicalOntology(unittest.TestCase):
+    """EDGE_TYPES is derived from EDGE_MODELS, no hand-rolled copies."""
+
+    def test_loads_from_schema(self):
+        from poc_v1.ontology.graphiti_views import EDGE_TYPES
+
+        self.assertGreater(len(EDGE_TYPES), 0)
+        for label, model in EDGE_TYPES.items():
+            self.assertIsInstance(label, str)
+            self.assertTrue(issubclass(model, BaseModel))
+
+    def test_contains_expected_canonical_edges(self):
+        from poc_v1.ontology.graphiti_views import EDGE_TYPES
+
+        expected = {
+            "FROM", "TO", "IN_MARKET", "RELEVANT_TO", "ABOUT",
+            "HAS_ATTRIBUTE", "HAS_LEVEL", "HAS_TRAIT", "RELEVANT_AT",
+            "SUPPORTS", "OFFERED_BY",
+        }
+        self.assertEqual(set(EDGE_TYPES) & expected, expected)
+
+    def test_every_edge_has_contract_entry(self):
+        """Mirror of the node-side invariant."""
+        from poc_v1.ontology.graphiti_views import EDGE_TYPES, _CONTRACT
+
+        contract_edges = set(_CONTRACT["edges"].keys())
+        ontology_edges = set(EDGE_TYPES.keys())
+        self.assertEqual(
+            ontology_edges, contract_edges,
+            f"drift: extra in ontology={ontology_edges - contract_edges}, "
+            f"extra in contract={contract_edges - ontology_edges}",
+        )
+
+
+class TestEdgeTypeMap(unittest.TestCase):
+    """EDGE_TYPE_MAP: dict[tuple[str, str], list[str]] — what
+    Graphiti.add_episode(edge_type_map=…) needs.
+
+    The contract's `from`/`to` fields can be a single string, a list,
+    or '*' (any). We expand all three into concrete (from_label,
+    to_label) keys.
+    """
+
+    def test_map_is_dict_keyed_by_tuple(self):
+        from poc_v1.ontology.graphiti_views import EDGE_TYPE_MAP
+
+        self.assertIsInstance(EDGE_TYPE_MAP, dict)
+        for key, value in EDGE_TYPE_MAP.items():
+            self.assertIsInstance(key, tuple)
+            self.assertEqual(len(key), 2)
+            self.assertIsInstance(value, list)
+
+    def test_simple_edge_routes_correctly(self):
+        """FROM is (Transition → Stage)."""
+        from poc_v1.ontology.graphiti_views import EDGE_TYPE_MAP
+
+        self.assertIn("FROM", EDGE_TYPE_MAP[("Transition", "Stage")])
+
+    def test_offered_by_edge_routes_correctly(self):
+        """OFFERED_BY is (Offering → Company)."""
+        from poc_v1.ontology.graphiti_views import EDGE_TYPE_MAP
+
+        self.assertIn("OFFERED_BY", EDGE_TYPE_MAP[("Offering", "Company")])
+
+    def test_polymorphic_from_expands(self):
+        """ABOUT has from=[Transition, Estimate], to=*."""
+        from poc_v1.ontology.graphiti_views import EDGE_TYPE_MAP
+
+        transition_keys = [
+            k for k in EDGE_TYPE_MAP
+            if k[0] == "Transition" and "ABOUT" in EDGE_TYPE_MAP[k]
+        ]
+        estimate_keys = [
+            k for k in EDGE_TYPE_MAP
+            if k[0] == "Estimate" and "ABOUT" in EDGE_TYPE_MAP[k]
+        ]
+        self.assertGreater(
+            len(transition_keys), 0,
+            "ABOUT should be reachable with Transition source",
+        )
+        self.assertGreater(
+            len(estimate_keys), 0,
+            "ABOUT should be reachable with Estimate source",
+        )
+
+    def test_wildcard_target_expands_to_canonical_nodes(self):
+        """SUPPORTS has from=Evidence, to=*."""
+        from poc_v1.ontology.graphiti_views import (
+            EDGE_TYPE_MAP,
+            ENTITY_TYPES,
+        )
+
+        evidence_targets = {
+            k[1] for k in EDGE_TYPE_MAP
+            if k[0] == "Evidence" and "SUPPORTS" in EDGE_TYPE_MAP[k]
+        }
+        self.assertTrue(
+            set(ENTITY_TYPES.keys()).issubset(evidence_targets),
+            f"missing wildcard targets: "
+            f"{set(ENTITY_TYPES.keys()) - evidence_targets}",
+        )
+
+    def test_polymorphic_target_expands(self):
+        """HAS_LEVEL has from=[Attribute, Trait], to=[AttributeLevel, TraitLevel]."""
+        from poc_v1.ontology.graphiti_views import EDGE_TYPE_MAP
+
+        self.assertIn("HAS_LEVEL", EDGE_TYPE_MAP[("Attribute", "AttributeLevel")])
+        self.assertIn("HAS_LEVEL", EDGE_TYPE_MAP[("Trait", "TraitLevel")])
+
+    def test_predicates_are_unique_within_a_cell(self):
+        from poc_v1.ontology.graphiti_views import EDGE_TYPE_MAP
+
+        for key, predicates in EDGE_TYPE_MAP.items():
+            self.assertEqual(
+                len(predicates), len(set(predicates)),
+                f"duplicate predicates at {key}: {predicates}",
+            )
+
+
+class TestGraphitiCompatibility(unittest.TestCase):
+    """ENTITY_TYPES / EDGE_TYPES go straight into Graphiti.add_episode().
+    Graphiti rejects any custom-type field that collides with its own
+    EntityNode/EntityEdge field names (graphiti_core/errors.py)."""
+
+    GRAPHITI_NODE_RESERVED = {
+        "uuid", "name", "group_id", "labels", "created_at",
+        "name_embedding", "summary", "attributes",
+    }
+    GRAPHITI_EDGE_RESERVED = {
+        "uuid", "group_id", "source_node_uuid", "target_node_uuid",
+        "created_at", "name", "fact", "fact_embedding", "episodes",
+        "expired_at", "valid_at", "invalid_at", "reference_time",
+        "attributes",
+    }
+
+    def test_entity_types_have_no_reserved_node_fields(self):
+        from poc_v1.ontology.graphiti_views import ENTITY_TYPES
+
+        for label, model in ENTITY_TYPES.items():
+            for field_name in model.model_fields:
+                self.assertNotIn(
+                    field_name, self.GRAPHITI_NODE_RESERVED,
+                    f"{label} exposes reserved field {field_name!r} — "
+                    f"graphiti will raise EntityTypeValidationError",
+                )
+
+    def test_edge_types_have_no_reserved_edge_fields(self):
+        from poc_v1.ontology.graphiti_views import EDGE_TYPES
+
+        for label, model in EDGE_TYPES.items():
+            for field_name in model.model_fields:
+                self.assertNotIn(
+                    field_name, self.GRAPHITI_EDGE_RESERVED,
+                    f"{label} exposes reserved field {field_name!r} — "
+                    f"graphiti will raise edge validation error",
+                )
+
+
+class TestNoHandwrittenSchemaInViews(unittest.TestCase):
+    """View models must be derived from canonical NODE_MODELS / EDGE_MODELS,
+    not hand-rolled. Any field not in the canonical model is a regression."""
+
+    def test_every_view_field_is_in_canonical(self):
+        from poc_v1.ontology.graphiti_views import ENTITY_TYPES, EDGE_TYPES
+        from poc_v1.ontology import schema as canonical
+
+        for label, view in ENTITY_TYPES.items():
+            cmodel = canonical.NODE_MODELS[label]
+            extra = set(view.model_fields) - set(cmodel.model_fields)
+            self.assertEqual(
+                extra, set(),
+                f"node view {label} has fields not in canonical: {extra}",
+            )
+        for label, view in EDGE_TYPES.items():
+            cmodel = canonical.EDGE_MODELS[label]
+            extra = set(view.model_fields) - set(cmodel.model_fields)
+            self.assertEqual(
+                extra, set(),
+                f"edge view {label} has fields not in canonical: {extra}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `poc_v1/ontology/graphiti_views.py` — a typed Pydantic view of the canonical NODE_MODELS / EDGE_MODELS, ready to drop into `Graphiti.add_episode(entity_types=..., edge_types=..., edge_type_map=...)`.

Also adds `tests/test_graphiti_views.py` (16 tests, all pass) covering: derivation correctness, polymorphic edge expansion, wildcard targets, predicate uniqueness, no-reserved-field-leakage.

## Why

The graphiti view is a property of the schema, not of any particular consumer. Today it lives in `burn-substrate/graphiti/ontology_types.py` (~180 LOC) where it has to be re-derived by every new consumer (twenty CRM projection next, causl.io agent after that).

Moving it next to the canonical models means:
- reserved-field stripping stays in lock-step with NODE_MODELS / EDGE_MODELS
- adding a new ontology type automatically gets a graphiti view
- new consumers import a ready-made view in 3 lines
- contract drift surfaces at import time in this module rather than at add_episode time in production

## Public API

```python
from poc_v1.ontology.graphiti_views import (
    ENTITY_TYPES,    # dict[str, type[BaseModel]]
    EDGE_TYPES,      # dict[str, type[BaseModel]]
    EDGE_TYPE_MAP,   # dict[tuple[str, str], list[str]]
    SCHEMA_VERSION,
)
```

## Risk

Very low — purely additive. No existing module imports it yet (the sidecar import swap ships in the paired dag-substrate PR). Existing tests pass: `Ran 53 tests, 3 errors` — the 3 errors are pre-existing on `main` (unrelated import errors in `test_causal_projection_contracts`, `test_validate_causal_projection`, `test_wandb_ontology_loop_contract`). My 16 new tests all pass; zero new failures introduced.

## No version bump

The new module is purely additive, schema is unchanged, and consumers install via `git+https://github.com/Subconscious-ai/market-ontology.git` (no version pin). A `SCHEMA_VERSION` bump would force regen of 4 stale-projection JSONs (`twenty_projection.json`, `super_ego_projection.json`, etc.) for no gating benefit.

## Test plan

- [x] All 16 new tests pass
- [x] No regression on the 50 pre-existing tests (still 3 errors, same as `origin/main`)
- [ ] Paired dag-substrate PR will replace `burn-substrate/graphiti/ontology_types.py` with `from poc_v1.ontology.graphiti_views import ENTITY_TYPES, EDGE_TYPES, EDGE_TYPE_MAP` and delete the duplicate (~180 LOC removed)