### PR TITLE
BEC-1844: Symphony canary: add tested market ontology glossary helper

### DIFF
--- a/poc_v1/ontology/glossary.py
+++ b/poc_v1/ontology/glossary.py
@@ -1,0 +1,10 @@
+"""Glossary display helpers."""
+from __future__ import annotations
+
+
+def normalize_glossary_term(term: str) -> str:
+    """Trim a glossary term and collapse internal whitespace for display."""
+    return " ".join(term.split())
+
+
+__all__ = ["normalize_glossary_term"]

--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -1,0 +1,40 @@
+"""Tests for glossary display helpers."""
+import unittest
+
+
+class TestNormalizeGlossaryTerm(unittest.TestCase):
+    def test_trims_leading_and_trailing_whitespace(self):
+        from poc_v1.ontology.glossary import normalize_glossary_term
+
+        self.assertEqual(
+            normalize_glossary_term("  Market transition  "),
+            "Market transition",
+        )
+
+    def test_collapses_repeated_spaces(self):
+        from poc_v1.ontology.glossary import normalize_glossary_term
+
+        self.assertEqual(
+            normalize_glossary_term("Market    transition"),
+            "Market transition",
+        )
+
+    def test_collapses_tabs_and_newlines(self):
+        from poc_v1.ontology.glossary import normalize_glossary_term
+
+        self.assertEqual(
+            normalize_glossary_term("Market\ttransition\nstage"),
+            "Market transition stage",
+        )
+
+    def test_already_clean_term_is_unchanged(self):
+        from poc_v1.ontology.glossary import normalize_glossary_term
+
+        self.assertEqual(
+            normalize_glossary_term("Market transition"),
+            "Market transition",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs BEC-1844

Linear: https://linear.app/subconscious/issue/BEC-1844/symphony-canary-add-tested-market-ontology-glossary-helper

This draft PR was published by Symphony after Codex completed the local branch work.
