### PR TITLE
Define accepted-state coordination spine

### DIFF
--- a/docs/accepted-state-cross-repo-smoke.md
+++ b/docs/accepted-state-cross-repo-smoke.md
@@ -1,0 +1,53 @@
+# Accepted-State Cross-Repo Smoke Skeleton
+
+This is the minimal smoke path for the accepted-state spine:
+
+```text
+Inputs -> Evidence Inbox -> Claim Adjudicator -> Twenty Accepted Records -> Projection Pack
+```
+
+accepted state lives in Twenty. The smoke proves each repo keeps that boundary
+visible before later implementation work proceeds.
+
+## market-ontology
+
+Owns schema, contracts, projection validation, source-of-truth drift checks,
+the lighthouse fixture skeleton, and this smoke skeleton.
+
+Command:
+
+```bash
+python3 tests/test_accepted_state_spine_contract.py -v
+```
+
+## spice-harvester
+
+Owns collection, source events, evidence candidates, claim candidates, and
+adjudication inputs. The smoke confirms Spice does not write accepted records.
+
+Command:
+
+```bash
+python3 -m pytest tests/test_accepted_state_spine_doc.py -q
+```
+
+## ai-chatbot
+
+Owns chat, Sizzle, review UI, accepted-state actions, projection display, and
+the approved server-side accepted-write boundary. The smoke confirms Graphiti,
+Falkor, and Zep cannot be accepted-record writers.
+
+Command:
+
+```bash
+pnpm exec tsx --test tests/unit/accepted-state-spine-doc.test.ts
+```
+
+## Gate
+
+The three repo smokes must answer:
+
+- Where does accepted truth live?
+- Which source-of-truth drift checks are active?
+- Where is the accepted-write boundary?
+- Which Projection Pack outputs are generated from accepted records?

--- a/docs/accepted-state-spine.md
+++ b/docs/accepted-state-spine.md
@@ -1,0 +1,16 @@
+# Accepted-State Spine Pointer
+
+market-ontology owns schema/contracts, projection validation, change classes,
+lighthouse fixtures, and source-of-truth drift checks for the accepted-state
+spine.
+
+Canonical ADR: `docs/adr/0001-accepted-state-spine.md`.
+
+Operating loop:
+
+```text
+Inputs -> Evidence Inbox -> Claim Adjudicator -> Twenty Accepted Records -> Projection Pack
+```
+
+Accepted state lives in Twenty. This repo does not own operational records; it
+owns the contract that accepted records and generated projections must satisfy.

--- a/docs/adr/0001-accepted-state-spine.md
+++ b/docs/adr/0001-accepted-state-spine.md
@@ -1,0 +1,148 @@
+# ADR 0001: Accepted-State Spine
+
+Status: Accepted
+Date: 2026-05-09
+
+## Decision
+
+Subconscious market intelligence uses this operating loop:
+
+```text
+Inputs -> Evidence Inbox -> Claim Adjudicator -> Twenty Accepted Records -> Projection Pack
+```
+
+accepted state lives in Twenty. collectors produce candidates. The Claim
+Adjudicator turns source-backed candidates into accepted, rejected, conflicted,
+or review-needed claims. The Projection Pack generates every downstream view
+from accepted Twenty records.
+
+## Store Boundaries
+
+- Twenty Accepted Records are the source of record for accepted operational
+  ontology state.
+- market-ontology owns schema, contracts, projection validation, change
+  classes, and fixture shape.
+- spice-harvester owns collection, source events, evidence candidates, claim
+  candidates, and adjudication inputs. It does not write accepted records.
+- ai-chatbot owns chat, Sizzle, review UI, accepted-state actions, and
+  projection display. Accepted writes go through approved server-side paths.
+- wiki and dossier are projections, not canonical stores.
+- kg_seed is superseded by ontology_snapshot as a generated projection
+  artifact. Existing kg_seed paths are compatibility surfaces until migrated.
+- Graphiti/Falkor is a retrieval projection. It never creates accepted state.
+- Zep is per-exec memory. It is not an ontology or accepted-state store.
+- Rowboat and PageIndex are not core-path dependencies. Rowboat may become an
+  optional input lane; PageIndex may become a long-document source index.
+- Spice accepted writes are blocked. Spice produces candidates only; it never
+  writes Twenty Accepted Records directly.
+
+## Change Classes
+
+| Class | Name | Rule |
+| --- | --- | --- |
+| Class 0 | local implementation | Stays inside one repo and does not touch contracts or accepted state. |
+| Class 1 | local contract-adjacent | Touches one repo's adapter, projection, or validation around an existing contract. |
+| Class 2 | cross-repo contract | Changes shared schema, generated contracts, or wire shape. Requires coordinated PRs. |
+| Class 3 | source-of-record / accepted-state | Changes Twenty accepted records or accepted-write policy. Requires human approval. |
+| Class 4 | breaking change | Removes or changes existing contract semantics. Requires ADR and migration plan. |
+
+## Forbidden Drift
+
+- Do not call wiki, dossier, Sizzle DAG, Graphiti, Falkor, Zep, Rowboat,
+  PageIndex, raw chunks, source events, evidence candidates, or claim
+  candidates canonical accepted state.
+- Do not load raw chunks into Twenty as accepted Evidence.
+- Do not include candidate claims in experiment context by default.
+- Do not let Graphiti, Falkor, or Zep write accepted records.
+- Do not introduce a parallel ontology in ai-chatbot, spice-harvester, or a
+  retrieval store.
+
+## Accepted Write Boundary
+
+Accepted writes are allowed only through approved server-side ai-chatbot paths
+that enforce tenancy, authorization, schema validation, audit metadata, and
+projection refresh. Ambiguous chat corrections become Evidence Inbox source
+events and ClaimCandidate records before adjudication. Explicit authorized
+corrections write a correction source event, update Twenty, and regenerate the
+Projection Pack.
+
+## Projection Pack
+
+The Projection Pack is generated from accepted Twenty records plus the
+market-ontology contract. It includes ontology_snapshot, Sizzle DAG data,
+generated wiki/dossier, experiment_context.json, and optional Graphiti/Falkor
+retrieval projection. Projection failure must never mutate Twenty.
+
+## Deprecation Matrix
+
+| Surface | New role |
+| --- | --- |
+| wiki/dossier | Projection only; generated from accepted records where possible |
+| kg_seed | Compatibility name for generated ontology_snapshot |
+| wiki/claims.jsonl | Compatibility adapter only; log usage |
+| Spice accepted writes | Blocked; Spice produces candidates only |
+| raw chunks | Extraction material only; not accepted Evidence |
+| Sizzle DAG | Accepted structure view only; not canonical |
+| Graphiti/Falkor | Retrieval projection only; never accepted state |
+| Zep | Per-exec memory only; not ontology truth |
+| Rowboat | Parked optional input lane; not core path |
+| PageIndex | Parked long-document source index; not core path |
+| LinkML | Deferred migration candidate; do not redesign schema |
+
+Compatibility readers for `kg_seed` or `wiki/claims.jsonl` must warn or log
+usage, then migrate consumers to Evidence Inbox, ClaimCandidate,
+AdjudicatedClaim, Twenty Accepted Records, or Projection Pack surfaces.
+
+## Cleanup Loop
+
+The new spine does not delete old lanes by itself. Cleanup is a governed loop:
+
+```text
+Inventory old lanes and data paths
+-> Classify
+-> Active / Compatibility only / Archived / Delete candidate
+-> Add warnings and drift checks
+-> Confirm no consumers
+-> Archive or remove
+```
+
+Delete obsolete code paths aggressively. Archive provenance carefully. Never delete lineage needed to explain a past decision or experiment.
+One accepted state. Many inputs. Many projections. No ghost canons.
+
+Accepted Twenty records should usually be archived or tombstoned before hard
+delete:
+
+```text
+status = archived
+valid_to = timestamp
+archived_reason = ...
+superseded_by = ...
+```
+
+Hard deletion is allowed only for never-accepted records, test/demo data, or
+records covered by an explicit retention policy with no snapshot, experiment,
+or evidence lineage dependency.
+
+Raw collector data may be removed only after durable provenance is preserved:
+
+```text
+source_ref
+source URL or path
+content hash
+excerpt used as evidence
+retrieval lane/query
+timestamp
+```
+
+The first cleanup pass is audit-only. It inventories, classifies, warns, and
+checks consumers; it does not hard-delete repo or runtime data.
+
+## Gates
+
+No later implementation should proceed until agents can answer:
+
+- Where does accepted truth live?
+- Which repo owns schema/contracts?
+- Which systems are projections or memories only?
+- Which change class applies?
+- Which tests prove source-of-truth drift is blocked?

--- a/poc_v1/contracts/examples/lighthouse_projection_pack.skeleton.json
+++ b/poc_v1/contracts/examples/lighthouse_projection_pack.skeleton.json
@@ -1,0 +1,36 @@
+{
+  "fixture_name": "lighthouse_projection_pack_skeleton",
+  "fixture_version": "0.1.0",
+  "source_of_record": "twenty",
+  "input_filter": "accepted_only",
+  "ontology_schema_version": "1.3.1",
+  "projection_version": "0.1.0",
+  "snapshot_hash": "sha256:lighthouse-skeleton",
+  "projection_timestamp": "2026-05-09T00:00:00Z",
+  "accepted_records": [],
+  "evidence_refs": [],
+  "outputs": {
+    "ontology_snapshot": {
+      "path": "ontology_snapshot/",
+      "status_filter": "accepted"
+    },
+    "sizzle_dag": {
+      "path": "sizzle_dag.json",
+      "status_filter": "accepted"
+    },
+    "wiki_dossier": {
+      "path": "wiki/",
+      "status_filter": "accepted"
+    },
+    "experiment_context": {
+      "path": "experiment_context.json",
+      "status_filter": "accepted"
+    },
+    "graphiti_projection": {
+      "path": "graphiti/",
+      "enabled": false,
+      "status_filter": "accepted"
+    }
+  },
+  "parking_lot": ["zep", "rowboat", "pageindex", "linkml"]
+}

--- a/scripts/agent/validate-fast.sh
+++ b/scripts/agent/validate-fast.sh
@@ -19,6 +19,7 @@ bash scripts/agent/preflight.sh
 "$PYTHON_BIN" scripts/validate_kg_seed.py
 "$PYTHON_BIN" scripts/generate_kg_seed_contract.py --check
 "$PYTHON_BIN" scripts/generate_twenty_app.py --check
+"$PYTHON_BIN" scripts/check_accepted_state_spine.py
 "$PYTHON_BIN" scripts/validate_causal_projection.py poc_v1/contracts/examples/causal_dag_projection.static.valid.json
 "$PYTHON_BIN" scripts/validate_causal_projection.py poc_v1/contracts/examples/causal_dag_projection.timeseries.valid.json
 "$PYTHON_BIN" -m unittest discover -s tests -v

--- a/scripts/check_accepted_state_spine.py
+++ b/scripts/check_accepted_state_spine.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Check accepted-state spine docs for source-of-truth drift."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ADR = ROOT / "docs" / "adr" / "0001-accepted-state-spine.md"
+POINTER = ROOT / "docs" / "accepted-state-spine.md"
+
+REQUIRED_PHRASES = [
+    "accepted state lives in Twenty",
+    "collectors produce candidates",
+    "wiki and dossier are projections",
+    "kg_seed is superseded by ontology_snapshot",
+    "Graphiti/Falkor is a retrieval projection",
+    "Zep is per-exec memory",
+    "Rowboat and PageIndex are not core-path dependencies",
+    "Accepted writes are allowed only through approved server-side ai-chatbot paths",
+]
+
+FORBIDDEN_PATTERNS = [
+    r"wiki\s+(is|as|becomes)\s+(the\s+)?canonical",
+    r"wiki\s+(is|as|becomes)\s+(the\s+)?source\s+of\s+truth",
+    r"dossier\s+(is|as|becomes)\s+(the\s+)?canonical",
+    r"dossier\s+(is|as|becomes)\s+(the\s+)?source\s+of\s+truth",
+    r"kg_seed\s+(is|as|becomes)\s+(the\s+)?canonical",
+    r"kg_seed\s+(is|as|becomes)\s+(the\s+)?source\s+of\s+truth",
+    r"(Sizzle\s+)?DAG\s+(is|as|becomes)\s+accepted\s+truth",
+    r"(Sizzle\s+)?DAG\s+(writes|creates|owns)\s+accepted",
+    r"Graphiti\s+(writes|creates|owns)\s+accepted",
+    r"Graphiti\s+(is|as|becomes)\s+accepted\s+truth",
+    r"Zep\s+(writes|creates|owns)\s+accepted",
+    r"Zep\s+(is|as|becomes)\s+accepted\s+truth",
+    r"raw chunks\s+(are|as|become)\s+accepted Evidence",
+    r"raw chunks\s+are\s+loaded\s+into\s+Twenty",
+    r"candidate claims\s+(enter|write to)\s+experiment context by default",
+]
+
+
+def _read(path: Path) -> str:
+    if not path.exists():
+        raise AssertionError(f"missing required spine file: {path.relative_to(ROOT)}")
+    return path.read_text(encoding="utf-8")
+
+
+def _check_required(text: str) -> list[str]:
+    return [f"ADR missing phrase: {phrase}" for phrase in REQUIRED_PHRASES if phrase not in text]
+
+
+def _check_forbidden(path: Path, text: str) -> list[str]:
+    errors: list[str] = []
+    for pattern in FORBIDDEN_PATTERNS:
+        if re.search(pattern, text, flags=re.IGNORECASE):
+            errors.append(
+                f"{_display_path(path)} matches forbidden drift pattern: {pattern}"
+            )
+    return errors
+
+
+def _display_path(path: Path) -> Path:
+    try:
+        return path.relative_to(ROOT)
+    except ValueError:
+        return path
+
+
+def main() -> int:
+    errors: list[str] = []
+    adr_text = _read(ADR)
+    pointer_text = _read(POINTER)
+
+    errors.extend(_check_required(adr_text))
+    for path, text in ((ADR, adr_text), (POINTER, pointer_text)):
+        errors.extend(_check_forbidden(path, text))
+
+    if errors:
+        for error in errors:
+            print(f"[accepted-state-spine] ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print("[accepted-state-spine] accepted-state-spine OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_causal_projection.py
+++ b/scripts/validate_causal_projection.py
@@ -13,6 +13,7 @@ import copy
 import json
 import sys
 from collections import deque
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +21,18 @@ from jsonschema import Draft202012Validator, FormatChecker
 
 ROOT = Path(__file__).parent.parent
 SCHEMA_PATH = ROOT / "poc_v1" / "contracts" / "causal_dag_projection.schema.json"
+FORMAT_CHECKER = FormatChecker()
+
+
+@FORMAT_CHECKER.checks("date-time")
+def _is_date_time(value: object) -> bool:
+    if not isinstance(value, str):
+        return True
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return True
 
 
 def _load_schema() -> dict[str, Any]:
@@ -27,7 +40,7 @@ def _load_schema() -> dict[str, Any]:
 
 
 def validate_json_schema(instance: dict[str, Any], schema: dict[str, Any]) -> list[str]:
-    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    validator = Draft202012Validator(schema, format_checker=FORMAT_CHECKER)
     return [
         error.message
         for error in sorted(validator.iter_errors(instance), key=lambda err: list(err.path))

--- a/tests/test_accepted_state_spine_contract.py
+++ b/tests/test_accepted_state_spine_contract.py
@@ -1,0 +1,160 @@
+import json
+import importlib.util
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ADR = ROOT / "docs" / "adr" / "0001-accepted-state-spine.md"
+CROSS_REPO_SMOKE = ROOT / "docs" / "accepted-state-cross-repo-smoke.md"
+FIXTURE = (
+    ROOT
+    / "poc_v1"
+    / "contracts"
+    / "examples"
+    / "lighthouse_projection_pack.skeleton.json"
+)
+
+
+class TestAcceptedStateSpineContract(unittest.TestCase):
+    def test_canonical_adr_names_operating_loop_and_store_boundaries(self):
+        text = ADR.read_text(encoding="utf-8")
+
+        required = [
+            "Inputs -> Evidence Inbox -> Claim Adjudicator -> Twenty Accepted Records -> Projection Pack",
+            "accepted state lives in Twenty",
+            "collectors produce candidates",
+            "wiki and dossier are projections",
+            "kg_seed is superseded by ontology_snapshot",
+            "Graphiti/Falkor is a retrieval projection",
+            "Zep is per-exec memory",
+            "Rowboat and PageIndex are not core-path dependencies",
+        ]
+        for phrase in required:
+            self.assertIn(phrase, text)
+
+    def test_change_classes_are_declared(self):
+        text = ADR.read_text(encoding="utf-8")
+
+        for index, label in {
+            0: "local implementation",
+            1: "local contract-adjacent",
+            2: "cross-repo contract",
+            3: "source-of-record / accepted-state",
+            4: "breaking change",
+        }.items():
+            self.assertIn(f"Class {index}", text)
+            self.assertIn(label, text)
+
+    def test_drift_and_accepted_write_checks_are_registered(self):
+        result = subprocess.run(
+            [sys.executable, "scripts/check_accepted_state_spine.py"],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertIn("accepted-state-spine OK", result.stdout)
+
+    def test_lighthouse_projection_pack_skeleton_is_minimal_and_accepted_only(self):
+        fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+        self.assertEqual(fixture["fixture_name"], "lighthouse_projection_pack_skeleton")
+        self.assertEqual(fixture["input_filter"], "accepted_only")
+        self.assertEqual(fixture["source_of_record"], "twenty")
+        self.assertIn("ontology_snapshot", fixture["outputs"])
+        self.assertIn("sizzle_dag", fixture["outputs"])
+        self.assertIn("experiment_context", fixture["outputs"])
+        self.assertEqual(fixture["parking_lot"], ["zep", "rowboat", "pageindex", "linkml"])
+
+    def test_cross_repo_smoke_skeleton_names_each_repo_gate(self):
+        text = CROSS_REPO_SMOKE.read_text(encoding="utf-8")
+
+        required = [
+            "market-ontology",
+            "spice-harvester",
+            "ai-chatbot",
+            "accepted state lives in Twenty",
+            "source-of-truth drift",
+            "accepted-write boundary",
+            "Projection Pack",
+        ]
+        for phrase in required:
+            self.assertIn(phrase, text)
+
+    def test_legacy_truth_paths_are_demoted_or_parked(self):
+        text = ADR.read_text(encoding="utf-8")
+
+        required = [
+            "wiki/dossier | Projection only; generated from accepted records where possible",
+            "kg_seed | Compatibility name for generated ontology_snapshot",
+            "wiki/claims.jsonl | Compatibility adapter only; log usage",
+            "Spice accepted writes | Blocked; Spice produces candidates only",
+            "Graphiti/Falkor | Retrieval projection only; never accepted state",
+            "Sizzle DAG | Accepted structure view only; not canonical",
+            "raw chunks | Extraction material only; not accepted Evidence",
+            "Zep | Per-exec memory only; not ontology truth",
+            "Rowboat | Parked optional input lane; not core path",
+            "PageIndex | Parked long-document source index; not core path",
+            "LinkML | Deferred migration candidate; do not redesign schema",
+        ]
+        for phrase in required:
+            self.assertIn(phrase, text)
+
+    def test_cleanup_loop_and_deletion_policy_are_declared(self):
+        text = ADR.read_text(encoding="utf-8")
+
+        required = [
+            "Inventory old lanes and data paths",
+            "Compatibility only",
+            "Delete candidate",
+            "Delete obsolete code paths aggressively",
+            "Archive provenance carefully",
+            "Never delete lineage needed to explain a past decision or experiment",
+            "One accepted state. Many inputs. Many projections. No ghost canons.",
+            "status = archived",
+            "valid_to",
+            "superseded_by",
+            "source_ref",
+            "content hash",
+            "retrieval lane/query",
+        ]
+        for phrase in required:
+            self.assertIn(phrase, text)
+
+    def test_drift_checker_catches_legacy_truth_regressions(self):
+        checker = _load_drift_checker()
+        bad_text = "\n".join(
+            [
+                "The Sizzle DAG is accepted truth for the app.",
+                "raw chunks are loaded into Twenty as Evidence.",
+                "Graphiti owns accepted state.",
+                "kg_seed is the source of truth for accepted ontology state.",
+                "wiki is the source of truth for accepted claims.",
+                "candidate claims enter experiment context by default.",
+            ]
+        )
+
+        errors = checker._check_forbidden(Path("bad.md"), bad_text)
+
+        self.assertGreaterEqual(len(errors), 6)
+
+
+def _load_drift_checker():
+    spec = importlib.util.spec_from_file_location(
+        "check_accepted_state_spine",
+        ROOT / "scripts" / "check_accepted_state_spine.py",
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate_causal_projection.py
+++ b/tests/test_validate_causal_projection.py
@@ -145,12 +145,11 @@ class ValidateCausalProjectionTest(unittest.TestCase):
         )
         self.assertTrue(any("Additional properties" in error.message for error in errors))
 
+        validator = load_validator()
         sample = valid_projection()
         sample["generated_at"] = "not-a-date"
-        errors = list(
-            Draft202012Validator(schema, format_checker=FormatChecker()).iter_errors(sample)
-        )
-        self.assertTrue(any("date-time" in error.message for error in errors))
+        errors = validator.validate_json_schema(sample, schema)
+        self.assertTrue(any("date-time" in error for error in errors))
 
     def test_rejects_unknown_edge_endpoint(self):
         validator = load_validator()


### PR DESCRIPTION
## Summary
- Add canonical accepted-state ADR and repo-local coordination docs.
- Add cleanup/deprecation loop, change classes, forbidden drift checks, accepted-write-boundary checks, lighthouse fixture skeleton, and cross-repo smoke skeleton.
- Make causal projection validation own date-time format checking instead of relying on optional jsonschema extras.

## Test Plan
- `bash scripts/agent/validate-fast.sh`
