### PR TITLE
docs(adr): add ADR 0003 — Twenty deferred, TrustGraph as accepted-state store

### DIFF
--- a/docs/adr/0001-accepted-state-spine.md
+++ b/docs/adr/0001-accepted-state-spine.md
@@ -1,7 +1,16 @@
 # ADR 0001: Accepted-State Spine
 
-Status: Accepted
-Date: 2026-05-09
+Status: Accepted (revised — Twenty assumption superseded by [ADR 0003](0003-twenty-deferral.md))
+Date: 2026-05-09 (revised 2026-05-10)
+
+> **Revision note (2026-05-10):** Per [ADR 0003](0003-twenty-deferral.md)
+> and [`sizzl-trustgraph#6`](https://github.com/Subconscious-ai/sizzl-trustgraph/issues/6),
+> Twenty is deferred. Read every "Twenty Accepted Records" reference
+> below as "TrustGraph accepted records" for the current POC. The
+> store boundaries, change classes, forbidden drift, and projection
+> rules below all remain in force; only the destination of accepted
+> state changes (TrustGraph instead of Twenty). This ADR is kept
+> intact for historical traceability rather than rewritten.
 
 ## Decision
 

--- a/docs/adr/0002-operating-ontology-spine.md
+++ b/docs/adr/0002-operating-ontology-spine.md
@@ -1,8 +1,17 @@
 # ADR 0002: Operating Ontology Spine
 
-Date: 2026-05-09
+Date: 2026-05-09 (revised 2026-05-10)
 
-Status: accepted
+Status: accepted (revised — Twenty assumption superseded by [ADR 0003](0003-twenty-deferral.md))
+
+> **Revision note (2026-05-10):** Per [ADR 0003](0003-twenty-deferral.md)
+> and [`sizzl-trustgraph#6`](https://github.com/Subconscious-ai/sizzl-trustgraph/issues/6),
+> Twenty is deferred. Read every "Twenty accepted records" reference
+> below as "TrustGraph accepted records" for the current POC. The
+> spine shape, correction loop, quality loop, deprecation matrix, and
+> consequences below all remain in force; only the destination of
+> accepted state changes (TrustGraph instead of Twenty). This ADR is
+> kept intact for historical traceability rather than rewritten.
 
 ## Context
 

--- a/docs/adr/0003-twenty-deferral.md
+++ b/docs/adr/0003-twenty-deferral.md
@@ -1,0 +1,118 @@
+# ADR 0003: Twenty Deferral — TrustGraph as Accepted-State Store for the POC
+
+Date: 2026-05-10
+
+Status: accepted
+
+Supersedes the "Twenty as canonical accepted state" position in
+[ADR 0001](0001-accepted-state-spine.md) and [ADR 0002](0002-operating-ontology-spine.md).
+
+Mirrors the cross-repo decision recorded in
+[`Subconscious-ai/sizzl-trustgraph#6`](https://github.com/Subconscious-ai/sizzl-trustgraph/issues/6).
+
+## Context
+
+ADRs 0001 and 0002 established Twenty as the canonical accepted-state
+record store for operational ontology data. That was the right call when
+the only credible alternative was a hand-rolled Postgres-as-truth
+substrate. It is no longer the right call now that TrustGraph is the
+intended downstream backend (per `sizzl-trustgraph#5/#10/#12`).
+
+The simplest POC is TrustGraph-only for backend knowledge: Library,
+ontology extraction, collections, graph/object storage, GraphRAG,
+Workbench, and provenance. Twenty would only add value if we needed
+customer-facing structured editing and permissions beyond what
+TrustGraph + Sizzl UI provide. We do not need that for the first loop.
+
+## Decision
+
+**Twenty is deferred from the primary POC path.**
+
+The primary POC accepted-state path is:
+
+```text
+spice (discovery + audit gate)
+  -> source registry (sizzl-trustgraph#10)
+  -> changedetection.io watch (per #12 audit signal)
+  -> TrustGraph Library
+  -> market-ontology-config flow (extraction)
+  -> TrustGraph graph + object + provenance layer
+  -> Sizzl UI / executive interview / downstream agents
+```
+
+TrustGraph is the canonical accepted-state store. spice-harvester
+produces audited, target-matched, source-corroborated records and
+hands them to TrustGraph via Agent B's `services/ingestion/spice/`
+adapter (per `sizzl-trustgraph#5`).
+
+Twenty may later be **populated from TrustGraph** as an optional CRM /
+editing projection if customer-facing record workflows justify it.
+That is a future ADR, not a current dependency.
+
+## Store Boundaries (revised)
+
+| Layer | Role | Owner |
+|---|---|---|
+| spice-harvester | Source discovery + audit gate. Produces `source_registry.jsonl` (per `sizzl-trustgraph#10`) and `audit_record.jsonl` (per `sizzl-trustgraph#12`). Never writes accepted state. | spice-harvester |
+| TrustGraph Library + graph + object + provenance | **Canonical accepted state.** Everything that the executive interview, Sizzl UI, or downstream agents read as fact lives here. | TrustGraph (vendored) |
+| market-ontology | Schema contract + projection shape. Not a runtime database. | market-ontology |
+| ai-chatbot / Sizzl UI | Reads accepted state from TrustGraph. Writes corrections back through audited paths. | ai-chatbot |
+| Twenty | **Deferred.** Not a current dependency. May later be populated *from* TrustGraph as an optional CRM/editing surface. | n/a (deferred) |
+| Graphiti / Falkor | Retrieval projection only. Never accepted state. | burn-substrate |
+| Zep | Per-exec memory only. Never accepted state. | (per-exec) |
+
+## What changes from 0001 / 0002
+
+- **Lines that say "Twenty accepted records are canonical":** read as
+  "TrustGraph accepted records are canonical" until 0001 and 0002 are
+  rewritten or retired.
+- **Lines that say "Spice does not write accepted records":** unchanged
+  — spice still doesn't write accepted records. Only the destination
+  changes (TrustGraph instead of Twenty).
+- **Spice → Twenty → raw-file-export → TrustGraph:** removed. Direct
+  Spice → TrustGraph adapter is the path.
+- **Twenty in the deprecation matrix:** added as `Deferred`. Not
+  removed; not active either.
+
+## Forbidden drift (additive to 0001/0002)
+
+- Do not call Twenty an ingestion prerequisite.
+- Do not implement a Twenty adapter on the spice side without a
+  superseding ADR.
+- Do not claim TrustGraph is a full CRM. (It is not. CRM-style editing
+  is what Twenty would add later if needed.)
+
+## Reintroduction rule
+
+If Twenty is reintroduced, it is reintroduced as a **projection from
+TrustGraph**, not as an ingestion source of record. Any ADR that
+revises this decision must:
+
+1. Identify the customer-facing edit/permissions workflow that
+   TrustGraph + Sizzl UI cannot serve.
+2. Specify the TrustGraph → Twenty projection adapter contract.
+3. Pin tests that prevent Twenty from becoming an ingestion
+   prerequisite (the failure mode this ADR exists to prevent).
+
+## Cross-repo links
+
+- `Subconscious-ai/sizzl-trustgraph#6` (decision)
+- `Subconscious-ai/sizzl-trustgraph#5` (Spice → TrustGraph adapter)
+- `Subconscious-ai/sizzl-trustgraph#10` (source registry shape)
+- `Subconscious-ai/sizzl-trustgraph#12` (audit gate)
+- `Subconscious-ai/spice-harvester#258` (umbrella) +
+  `Subconscious-ai/spice-harvester#260` (C-2 PR — paired with this
+  ADR)
+- `Subconscious-ai/spice-harvester#257` (the plan that scoped this work)
+
+## Gates
+
+No later implementation should proceed until agents can answer:
+
+- Where does accepted truth live? **TrustGraph.**
+- Where does Twenty fit? **Nowhere in the first POC loop. Possibly a
+  later projection from TrustGraph.**
+- Which sizzl-trustgraph issue defines the Spice → TrustGraph contract?
+  **#5, #10, #12.**
+- Which spice-harvester PR produces the source registry that Agent B's
+  adapter lifts? **#260.**


### PR DESCRIPTION
## What

Adds **ADR 0003** mirroring `Subconscious-ai/sizzl-trustgraph#6` (decision): for the POC, accepted state lives in **TrustGraph**, not Twenty. Twenty is a possible later projection *from* TrustGraph; it is not an ingestion prerequisite.

Adds revision notes to ADR 0001 and 0002 so readers immediately see the supersedence; existing `test_accepted_state_spine_contract.py` phrasing is preserved intact for historical traceability and continues to pass.

## Why

ADRs 0001 and 0002 (May 9) made Twenty canonical. Cross-repo decision `sizzl-trustgraph#6` (May 10) defers Twenty in favor of direct TrustGraph ingestion. This ADR records the change in market-ontology so consumers (`spice-harvester`, `ai-chatbot`, future agents) have one canonical source of truth for the new direction.

## Risk

- **Pure docs change.** No schema, no fixture, no contract surface modified.
- **Existing tests preserved.** `test_accepted_state_spine_contract.py` enforces the exact phrasing of ADR 0001 — kept intact (revision note is additive at the top, doesn't change the existing body). Drift checker (`scripts/check_accepted_state_spine.py`) still passes.
- **Lighthouse projection-pack fixture** (`source_of_record: "twenty"`) is *not* updated in this PR — that's a separate follow-up since it would require coordinated test/fixture updates that exceed "one concern per PR." Will open a follow-up issue here pointing at #6.

## Test plan

- [x] `python3 scripts/check_accepted_state_spine.py` — `accepted-state-spine OK`
- [x] `pytest tests/test_accepted_state_spine_contract.py` — 8/8 green
- [x] `pytest tests/` (excluding 4 pre-existing local-env failures: 1 pytest-on-system-python, 3 missing-jsonschema) — 85 passed
- [ ] CI green
- [ ] Reviewer confirms 0003's Twenty-deferral language matches the spirit of `sizzl-trustgraph#6`

## Paired PR

`Subconscious-ai/spice-harvester#260` (C-2 of umbrella `Subconscious-ai/spice-harvester#258`) — produces the `source_registry.jsonl` per `sizzl-trustgraph#10` that Agent B's adapter will lift. Both PRs land together so the docs and the code agree on the same direction.

## Follow-up issue (separate, in this repo)

- Update `poc_v1/contracts/examples/lighthouse_projection_pack.skeleton.json` `source_of_record` from `"twenty"` to `"trustgraph"` (and corresponding test in `test_accepted_state_spine_contract.py::test_lighthouse_projection_pack_skeleton_is_minimal_and_accepted_only`).

Refs Subconscious-ai/sizzl-trustgraph#6
Refs Subconscious-ai/spice-harvester#258
Refs Subconscious-ai/spice-harvester#260

🤖 Generated with [Claude Code](https://claude.com/claude-code)