### PR TITLE
feat(trustgraph): ship TG ontology RAG projection with rich class prose

### DIFF
--- a/poc_v1/ontology/trustgraph_ontology.json
+++ b/poc_v1/ontology/trustgraph_ontology.json
@@ -1,0 +1,478 @@
+{
+  "metadata": {
+    "id": "sizzl-market-v1",
+    "name": "Sizzl Market Ontology",
+    "namespace": "https://causl.io/ontology/sizzl/v1#",
+    "description": "TrustGraph Ontology RAG projection of the canonical Sizzl market ontology.",
+    "schemaVersion": "1.3.1",
+    "projectionVersion": "1.0.0"
+  },
+  "classes": {
+    "SizzlEntity": {
+      "uri": "https://causl.io/ontology/sizzl/v1#SizzlEntity",
+      "type": "owl:Class",
+      "rdfs:label": [
+        {
+          "value": "Sizzl Entity",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Root class for all Sizzl market-ontology entities. Do not emit instances of this class directly; use one of the concrete subclasses below.",
+      "dcterms:identifier": "SizzlEntity"
+    },
+    "Market": {
+      "uri": "https://causl.io/ontology/sizzl/v1#Market",
+      "type": "owl:Class",
+      "rdfs:label": [
+        {
+          "value": "Market",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "A bounded competitive space in which Companies offer Offerings to StakeholderArchetypes \u2014 e.g. the smartphone market, the AI-platform market, the at-home baking market.",
+      "rdfs:subClassOf": "SizzlEntity",
+      "dcterms:identifier": "Market"
+    },
+    "Stage": {
+      "uri": "https://causl.io/ontology/sizzl/v1#Stage",
+      "type": "owl:Class",
+      "rdfs:label": [
+        {
+          "value": "Stage",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "A discrete step in a buyer's decision journey through a Market \u2014 e.g. for SaaS: \"awareness\", \"trial-signup\", \"trial-active\", \"upgrade\", \"renewal\". Attributes can be relevantAt different Stages.",
+      "rdfs:subClassOf": "SizzlEntity",
+      "dcterms:identifier": "Stage"
+    },
+    "Transition": {
+      "uri": "https://causl.io/ontology/sizzl/v1#Transition",
+      "type": "owl:Class",
+      "rdfs:label": [
+        {
+          "value": "Transition",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "A move from one Stage to another, in scope of one Market, relevant to one StakeholderArchetype \u2014 e.g. trial-signup \u2192 trial-active, relevant to the price-sensitive small-business owner archetype. Captures funnel dynamics.",
+      "rdfs:subClassOf": "SizzlEntity",
+      "dcterms:identifier": "Transition"
+    },
+    "StakeholderArchetype": {
+      "uri": "https://causl.io/ontology/sizzl/v1#StakeholderArchetype",
+      "type": "owl:Class",
+      "rdfs:label": [
+        {
+          "value": "StakeholderArchetype",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "A type of buyer, user, decision-maker, or other stakeholder whose preferences shape decisions in a Market \u2014 e.g. a CTO evaluating an AI platform, a parent buying baking mix, a small-business owner choosing a payments processor.",
+      "rdfs:subClassOf": "SizzlEntity",
+      "dcterms:identifier": "StakeholderArchetype"
+    },
+    "Offering": {
+      "uri": "https://causl.io/ontology/sizzl/v1#Offering",
+      "type": "owl:Class",
+      "rdfs:label": [
+        {
+          "value": "Offering",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "A specific product or service a Company brings to a Market \u2014 e.g. iPhone Pro Max, IBM watsonx, Pillsbury Grands biscuits, Notion AI add-on.",
+      "rdfs:subClassOf": "SizzlEntity",
+      "dcterms:identifier": "Offering"
+    },
+    "Attribute": {
+      "uri": "https://causl.io/ontology/sizzl/v1#Attribute",
+      "type": "owl:Class",
+      "rdfs:label": [
+        {
+          "value": "Attribute",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "A specific dimension of an Offering that buyers compare on when choosing between products \u2014 e.g. price tier, ecosystem integration, ingredient quality, API latency, customer-support tier. Always tied to an Offering via hasAttribute.",
+      "rdfs:subClassOf": "SizzlEntity",
+      "dcterms:identifier": "Attribute"
+    },
+    "AttributeLevel": {
+      "uri": "https://causl.io/ontology/sizzl/v1#AttributeLevel",
+      "type": "owl:Class",
+      "rdfs:label": [
+        {
+          "value": "AttributeLevel",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "A specific value an Attribute can take in a comparison \u2014 e.g. for Attribute 'price tier': levels 'premium', 'mid-market', 'value'; for Attribute 'API latency': levels '<100ms', '100-500ms', '>500ms'. Always tied to an Attribute via hasLevel.",
+      "rdfs:subClassOf": "SizzlEntity",
+      "dcterms:identifier": "AttributeLevel"
+    },
+    "Trait": {
+      "uri": "https://causl.io/ontology/sizzl/v1#Trait",
+      "type": "owl:Class",
+      "rdfs:label": [
+        {
+          "value": "Trait",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "A specific property of a StakeholderArchetype that drives their preferences \u2014 e.g. price-sensitivity, brand-loyalty, risk-tolerance, technical-fluency, time-on-platform. Always tied to a StakeholderArchetype via hasTrait.",
+      "rdfs:subClassOf": "SizzlEntity",
+      "dcterms:identifier": "Trait"
+    },
+    "TraitLevel": {
+      "uri": "https://causl.io/ontology/sizzl/v1#TraitLevel",
+      "type": "owl:Class",
+      "rdfs:label": [
+        {
+          "value": "TraitLevel",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "A specific value a Trait can take \u2014 e.g. for Trait 'price-sensitivity': levels 'high', 'medium', 'low'; for Trait 'technical-fluency': levels 'novice', 'intermediate', 'expert'. Always tied to a Trait via hasLevel.",
+      "rdfs:subClassOf": "SizzlEntity",
+      "dcterms:identifier": "TraitLevel"
+    },
+    "Evidence": {
+      "uri": "https://causl.io/ontology/sizzl/v1#Evidence",
+      "type": "owl:Class",
+      "rdfs:label": [
+        {
+          "value": "Evidence",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "A claim grounded in a source, used to support or refute an ontology fact \u2014 e.g. \"23% of Notion trial users convert to AI tier (Notion Q3 report)\", \"iPhone 15 Pro Max is $1199 at apple.com/shop\". Always cites a sourceRef or sourceUrl.",
+      "rdfs:subClassOf": "SizzlEntity",
+      "dcterms:identifier": "Evidence"
+    },
+    "Estimate": {
+      "uri": "https://causl.io/ontology/sizzl/v1#Estimate",
+      "type": "owl:Class",
+      "rdfs:label": [
+        {
+          "value": "Estimate",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "A numerical or qualitative prediction about an Offering, Market, or stakeholder behavior \u2014 e.g. \"India iPhone market will reach 50M units by 2027\", \"AI conversion rate will double if pricing is bundled\". Carries a confidence score and a value.",
+      "rdfs:subClassOf": "SizzlEntity",
+      "dcterms:identifier": "Estimate"
+    },
+    "Company": {
+      "uri": "https://causl.io/ontology/sizzl/v1#Company",
+      "type": "owl:Class",
+      "rdfs:label": [
+        {
+          "value": "Company",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "A real-world commercial organization that offers products or services in a market \u2014 e.g. Apple, IBM, Pillsbury, OpenAI.",
+      "rdfs:subClassOf": "SizzlEntity",
+      "dcterms:identifier": "Company"
+    },
+    "ExperimentRun": {
+      "uri": "https://causl.io/ontology/sizzl/v1#ExperimentRun",
+      "type": "owl:Class",
+      "rdfs:label": [
+        {
+          "value": "ExperimentRun",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "A specific test, study, or trial run to validate an Estimate or discover an Attribute \u2014 e.g. an A/B price test, a customer interview round, a usability study, a synthetic-respondent Subconscious.ai run. Has a date range and produces Estimates.",
+      "rdfs:subClassOf": "SizzlEntity",
+      "dcterms:identifier": "ExperimentRun"
+    }
+  },
+  "objectProperties": {
+    "fromStage": {
+      "uri": "https://causl.io/ontology/sizzl/v1#fromStage",
+      "type": "owl:ObjectProperty",
+      "rdfs:label": [
+        {
+          "value": "from stage",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Connects a transition to the stage it starts from.",
+      "rdfs:domain": "Transition",
+      "rdfs:range": "Stage"
+    },
+    "toStage": {
+      "uri": "https://causl.io/ontology/sizzl/v1#toStage",
+      "type": "owl:ObjectProperty",
+      "rdfs:label": [
+        {
+          "value": "to stage",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Connects a transition to the stage it moves to.",
+      "rdfs:domain": "Transition",
+      "rdfs:range": "Stage"
+    },
+    "inMarket": {
+      "uri": "https://causl.io/ontology/sizzl/v1#inMarket",
+      "type": "owl:ObjectProperty",
+      "rdfs:label": [
+        {
+          "value": "in market",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Connects a transition to its market scope.",
+      "rdfs:domain": "Transition",
+      "rdfs:range": "Market"
+    },
+    "relevantTo": {
+      "uri": "https://causl.io/ontology/sizzl/v1#relevantTo",
+      "type": "owl:ObjectProperty",
+      "rdfs:label": [
+        {
+          "value": "relevant to",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Connects a transition to a relevant stakeholder archetype.",
+      "rdfs:domain": "Transition",
+      "rdfs:range": "StakeholderArchetype"
+    },
+    "about": {
+      "uri": "https://causl.io/ontology/sizzl/v1#about",
+      "type": "owl:ObjectProperty",
+      "rdfs:label": [
+        {
+          "value": "about",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Connects a transition or estimate to the entity it describes."
+    },
+    "hasAttribute": {
+      "uri": "https://causl.io/ontology/sizzl/v1#hasAttribute",
+      "type": "owl:ObjectProperty",
+      "rdfs:label": [
+        {
+          "value": "has attribute",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Connects an offering to one of its market attributes.",
+      "rdfs:domain": "Offering",
+      "rdfs:range": "Attribute"
+    },
+    "hasLevel": {
+      "uri": "https://causl.io/ontology/sizzl/v1#hasLevel",
+      "type": "owl:ObjectProperty",
+      "rdfs:label": [
+        {
+          "value": "has level",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Connects an attribute or trait to a possible level."
+    },
+    "hasTrait": {
+      "uri": "https://causl.io/ontology/sizzl/v1#hasTrait",
+      "type": "owl:ObjectProperty",
+      "rdfs:label": [
+        {
+          "value": "has trait",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Connects a stakeholder archetype to a trait.",
+      "rdfs:domain": "StakeholderArchetype",
+      "rdfs:range": "Trait"
+    },
+    "relevantAt": {
+      "uri": "https://causl.io/ontology/sizzl/v1#relevantAt",
+      "type": "owl:ObjectProperty",
+      "rdfs:label": [
+        {
+          "value": "relevant at",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Connects an attribute to the journey stage where it is relevant.",
+      "rdfs:domain": "Attribute",
+      "rdfs:range": "Stage"
+    },
+    "supports": {
+      "uri": "https://causl.io/ontology/sizzl/v1#supports",
+      "type": "owl:ObjectProperty",
+      "rdfs:label": [
+        {
+          "value": "supports",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Connects evidence to the ontology entity or claim it supports."
+    },
+    "offeredBy": {
+      "uri": "https://causl.io/ontology/sizzl/v1#offeredBy",
+      "type": "owl:ObjectProperty",
+      "rdfs:label": [
+        {
+          "value": "offered by",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Connects an offering to its company.",
+      "rdfs:domain": "Offering",
+      "rdfs:range": "Company"
+    },
+    "consumed": {
+      "uri": "https://causl.io/ontology/sizzl/v1#consumed",
+      "type": "owl:ObjectProperty",
+      "rdfs:label": [
+        {
+          "value": "consumed",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Connects an experiment run to ontology context it consumed."
+    },
+    "produced": {
+      "uri": "https://causl.io/ontology/sizzl/v1#produced",
+      "type": "owl:ObjectProperty",
+      "rdfs:label": [
+        {
+          "value": "produced",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Connects an experiment run to an estimate it produced.",
+      "rdfs:domain": "ExperimentRun",
+      "rdfs:range": "Estimate"
+    }
+  },
+  "datatypeProperties": {
+    "sizzlId": {
+      "uri": "https://causl.io/ontology/sizzl/v1#sizzlId",
+      "type": "owl:DatatypeProperty",
+      "rdfs:label": [
+        {
+          "value": "Sizzl ID",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Extraction property for canonical field id.",
+      "rdfs:range": "xsd:string"
+    },
+    "name": {
+      "uri": "https://causl.io/ontology/sizzl/v1#name",
+      "type": "owl:DatatypeProperty",
+      "rdfs:label": [
+        {
+          "value": "name",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Extraction property for canonical field name.",
+      "rdfs:range": "xsd:string"
+    },
+    "definition": {
+      "uri": "https://causl.io/ontology/sizzl/v1#definition",
+      "type": "owl:DatatypeProperty",
+      "rdfs:label": [
+        {
+          "value": "definition",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Extraction property for canonical field definition.",
+      "rdfs:range": "xsd:string"
+    },
+    "schemaVersion": {
+      "uri": "https://causl.io/ontology/sizzl/v1#schemaVersion",
+      "type": "owl:DatatypeProperty",
+      "rdfs:label": [
+        {
+          "value": "schema version",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Extraction property for canonical field schema_version.",
+      "rdfs:range": "xsd:string"
+    },
+    "validFrom": {
+      "uri": "https://causl.io/ontology/sizzl/v1#validFrom",
+      "type": "owl:DatatypeProperty",
+      "rdfs:label": [
+        {
+          "value": "valid from",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Extraction property for canonical field valid_from.",
+      "rdfs:range": "xsd:date"
+    },
+    "validTo": {
+      "uri": "https://causl.io/ontology/sizzl/v1#validTo",
+      "type": "owl:DatatypeProperty",
+      "rdfs:label": [
+        {
+          "value": "valid to",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Extraction property for canonical field valid_to.",
+      "rdfs:range": "xsd:date"
+    },
+    "confidence": {
+      "uri": "https://causl.io/ontology/sizzl/v1#confidence",
+      "type": "owl:DatatypeProperty",
+      "rdfs:label": [
+        {
+          "value": "confidence",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Extraction property for canonical field confidence.",
+      "rdfs:range": "xsd:double"
+    },
+    "sourceRef": {
+      "uri": "https://causl.io/ontology/sizzl/v1#sourceRef",
+      "type": "owl:DatatypeProperty",
+      "rdfs:label": [
+        {
+          "value": "source reference",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Extraction property for canonical field source_ref.",
+      "rdfs:range": "xsd:string"
+    },
+    "sourceUrl": {
+      "uri": "https://causl.io/ontology/sizzl/v1#sourceUrl",
+      "type": "owl:DatatypeProperty",
+      "rdfs:label": [
+        {
+          "value": "source URL",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Extraction property for canonical field source_url.",
+      "rdfs:range": "xsd:anyURI"
+    },
+    "extractedClaim": {
+      "uri": "https://causl.io/ontology/sizzl/v1#extractedClaim",
+      "type": "owl:DatatypeProperty",
+      "rdfs:label": [
+        {
+          "value": "extracted claim",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Extraction property for canonical field extracted_claim.",
+      "rdfs:range": "xsd:string"
+    }
+  }
+}

--- a/poc_v1/ontology/trustgraph_projection.json
+++ b/poc_v1/ontology/trustgraph_projection.json
@@ -1,0 +1,164 @@
+{
+  "$schema": "https://causl.io/schemas/trustgraph-ontology-projection.json",
+  "projectionVersion": "1.0.0",
+  "ontologyId": "sizzl-market-v1",
+  "name": "Sizzl Market Ontology",
+  "namespace": "https://causl.io/ontology/sizzl/v1#",
+  "description": "TrustGraph Ontology RAG projection of the canonical Sizzl market ontology.",
+  "rootClass": {
+    "id": "SizzlEntity",
+    "label": "Sizzl Entity",
+    "comment": "Root class for all Sizzl market-ontology entities. Do not emit instances of this class directly; use one of the concrete subclasses below."
+  },
+  "classes": {
+    "Market": {
+      "label": "Market",
+      "comment": "A bounded competitive space in which Companies offer Offerings to StakeholderArchetypes — e.g. the smartphone market, the AI-platform market, the at-home baking market."
+    },
+    "Stage": {
+      "label": "Stage",
+      "comment": "A discrete step in a buyer's decision journey through a Market — e.g. for SaaS: \"awareness\", \"trial-signup\", \"trial-active\", \"upgrade\", \"renewal\". Attributes can be relevantAt different Stages."
+    },
+    "Transition": {
+      "label": "Transition",
+      "comment": "A move from one Stage to another, in scope of one Market, relevant to one StakeholderArchetype — e.g. trial-signup → trial-active, relevant to the price-sensitive small-business owner archetype. Captures funnel dynamics."
+    },
+    "StakeholderArchetype": {
+      "label": "StakeholderArchetype",
+      "comment": "A type of buyer, user, decision-maker, or other stakeholder whose preferences shape decisions in a Market — e.g. a CTO evaluating an AI platform, a parent buying baking mix, a small-business owner choosing a payments processor."
+    },
+    "Offering": {
+      "label": "Offering",
+      "comment": "A specific product or service a Company brings to a Market — e.g. iPhone Pro Max, IBM watsonx, Pillsbury Grands biscuits, Notion AI add-on."
+    },
+    "Attribute": {
+      "label": "Attribute",
+      "comment": "A specific dimension of an Offering that buyers compare on when choosing between products — e.g. price tier, ecosystem integration, ingredient quality, API latency, customer-support tier. Always tied to an Offering via hasAttribute."
+    },
+    "AttributeLevel": {
+      "label": "AttributeLevel",
+      "comment": "A specific value an Attribute can take in a comparison — e.g. for Attribute 'price tier': levels 'premium', 'mid-market', 'value'; for Attribute 'API latency': levels '<100ms', '100-500ms', '>500ms'. Always tied to an Attribute via hasLevel."
+    },
+    "Trait": {
+      "label": "Trait",
+      "comment": "A specific property of a StakeholderArchetype that drives their preferences — e.g. price-sensitivity, brand-loyalty, risk-tolerance, technical-fluency, time-on-platform. Always tied to a StakeholderArchetype via hasTrait."
+    },
+    "TraitLevel": {
+      "label": "TraitLevel",
+      "comment": "A specific value a Trait can take — e.g. for Trait 'price-sensitivity': levels 'high', 'medium', 'low'; for Trait 'technical-fluency': levels 'novice', 'intermediate', 'expert'. Always tied to a Trait via hasLevel."
+    },
+    "Evidence": {
+      "label": "Evidence",
+      "comment": "A claim grounded in a source, used to support or refute an ontology fact — e.g. \"23% of Notion trial users convert to AI tier (Notion Q3 report)\", \"iPhone 15 Pro Max is $1199 at apple.com/shop\". Always cites a sourceRef or sourceUrl."
+    },
+    "Estimate": {
+      "label": "Estimate",
+      "comment": "A numerical or qualitative prediction about an Offering, Market, or stakeholder behavior — e.g. \"India iPhone market will reach 50M units by 2027\", \"AI conversion rate will double if pricing is bundled\". Carries a confidence score and a value."
+    },
+    "Company": {
+      "label": "Company",
+      "comment": "A real-world commercial organization that offers products or services in a market — e.g. Apple, IBM, Pillsbury, OpenAI."
+    },
+    "ExperimentRun": {
+      "label": "ExperimentRun",
+      "comment": "A specific test, study, or trial run to validate an Estimate or discover an Attribute — e.g. an A/B price test, a customer interview round, a usability study, a synthetic-respondent Subconscious.ai run. Has a date range and produces Estimates."
+    }
+  },
+  "objectProperties": {
+    "fromStage": {
+      "edgeLabel": "FROM",
+      "label": "from stage",
+      "comment": "Connects a transition to the stage it starts from.",
+      "domain": "Transition",
+      "range": "Stage"
+    },
+    "toStage": {
+      "edgeLabel": "TO",
+      "label": "to stage",
+      "comment": "Connects a transition to the stage it moves to.",
+      "domain": "Transition",
+      "range": "Stage"
+    },
+    "inMarket": {
+      "edgeLabel": "IN_MARKET",
+      "label": "in market",
+      "comment": "Connects a transition to its market scope.",
+      "domain": "Transition",
+      "range": "Market"
+    },
+    "relevantTo": {
+      "edgeLabel": "RELEVANT_TO",
+      "label": "relevant to",
+      "comment": "Connects a transition to a relevant stakeholder archetype.",
+      "domain": "Transition",
+      "range": "StakeholderArchetype"
+    },
+    "about": {
+      "edgeLabel": "ABOUT",
+      "label": "about",
+      "comment": "Connects a transition or estimate to the entity it describes."
+    },
+    "hasAttribute": {
+      "edgeLabel": "HAS_ATTRIBUTE",
+      "label": "has attribute",
+      "comment": "Connects an offering to one of its market attributes.",
+      "domain": "Offering",
+      "range": "Attribute"
+    },
+    "hasLevel": {
+      "edgeLabel": "HAS_LEVEL",
+      "label": "has level",
+      "comment": "Connects an attribute or trait to a possible level."
+    },
+    "hasTrait": {
+      "edgeLabel": "HAS_TRAIT",
+      "label": "has trait",
+      "comment": "Connects a stakeholder archetype to a trait.",
+      "domain": "StakeholderArchetype",
+      "range": "Trait"
+    },
+    "relevantAt": {
+      "edgeLabel": "RELEVANT_AT",
+      "label": "relevant at",
+      "comment": "Connects an attribute to the journey stage where it is relevant.",
+      "domain": "Attribute",
+      "range": "Stage"
+    },
+    "supports": {
+      "edgeLabel": "SUPPORTS",
+      "label": "supports",
+      "comment": "Connects evidence to the ontology entity or claim it supports."
+    },
+    "offeredBy": {
+      "edgeLabel": "OFFERED_BY",
+      "label": "offered by",
+      "comment": "Connects an offering to its company.",
+      "domain": "Offering",
+      "range": "Company"
+    },
+    "consumed": {
+      "edgeLabel": "CONSUMED",
+      "label": "consumed",
+      "comment": "Connects an experiment run to ontology context it consumed."
+    },
+    "produced": {
+      "edgeLabel": "PRODUCED",
+      "label": "produced",
+      "comment": "Connects an experiment run to an estimate it produced.",
+      "domain": "ExperimentRun",
+      "range": "Estimate"
+    }
+  },
+  "datatypeProperties": {
+    "sizzlId": {"field": "id", "label": "Sizzl ID", "range": "xsd:string"},
+    "name": {"field": "name", "label": "name", "range": "xsd:string"},
+    "definition": {"field": "definition", "label": "definition", "range": "xsd:string"},
+    "schemaVersion": {"field": "schema_version", "label": "schema version", "range": "xsd:string"},
+    "validFrom": {"field": "valid_from", "label": "valid from", "range": "xsd:date"},
+    "validTo": {"field": "valid_to", "label": "valid to", "range": "xsd:date"},
+    "confidence": {"field": "confidence", "label": "confidence", "range": "xsd:double"},
+    "sourceRef": {"field": "source_ref", "label": "source reference", "range": "xsd:string"},
+    "sourceUrl": {"field": "source_url", "label": "source URL", "range": "xsd:anyURI"},
+    "extractedClaim": {"field": "extracted_claim", "label": "extracted claim", "range": "xsd:string"}
+  }
+}

--- a/scripts/generate_trustgraph_ontology.py
+++ b/scripts/generate_trustgraph_ontology.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Generate/check the TrustGraph Ontology RAG projection."""
+
+import argparse
+import difflib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from poc_v1.ontology import schema  # noqa: E402
+
+PROJECTION_PATH = ROOT / "poc_v1" / "ontology" / "trustgraph_projection.json"
+ONTOLOGY_PATH = ROOT / "poc_v1" / "ontology" / "trustgraph_ontology.json"
+
+
+def load_projection() -> dict[str, Any]:
+    return json.loads(PROJECTION_PATH.read_text(encoding="utf-8"))
+
+
+def _label(value: str) -> list[dict[str, str]]:
+    return [{"value": value, "lang": "en"}]
+
+
+def _assert_edge_coverage(projection: dict[str, Any]) -> None:
+    seen = {}
+    for prop_id, spec in projection["objectProperties"].items():
+        edge_label = spec["edgeLabel"]
+        if edge_label in seen:
+            raise SystemExit(
+                f"edge label {edge_label} mapped by both {seen[edge_label]} and {prop_id}"
+            )
+        seen[edge_label] = prop_id
+    expected = set(schema.EDGE_MODELS)
+    actual = set(seen)
+    if expected != actual:
+        raise SystemExit(
+            "TrustGraph object property drift: "
+            f"missing={sorted(expected - actual)} extra={sorted(actual - expected)}"
+        )
+
+
+def _assert_class_coverage(projection: dict[str, Any]) -> None:
+    """Every entity in schema.NODE_MODELS must have a class-level spec
+    (label + comment) in projection["classes"]. Adding/removing a Pydantic
+    model forces a corresponding projection update — fail loud here so
+    drift can't ship silently."""
+    expected = set(schema.NODE_MODELS)
+    actual = set(projection.get("classes", {}))
+    if expected != actual:
+        raise SystemExit(
+            "TrustGraph class projection drift: "
+            f"missing={sorted(expected - actual)} extra={sorted(actual - expected)}"
+        )
+
+
+def _object_property(namespace: str, prop_id: str, spec: dict[str, Any], class_ids: set[str]) -> dict[str, Any]:
+    out = {
+        "uri": f"{namespace}{prop_id}",
+        "type": "owl:ObjectProperty",
+        "rdfs:label": _label(spec["label"]),
+        "rdfs:comment": spec["comment"],
+    }
+    for key, rdf_key in (("domain", "rdfs:domain"), ("range", "rdfs:range")):
+        value = spec.get(key)
+        if not value:
+            continue
+        if value not in class_ids:
+            raise SystemExit(f"{prop_id}: unknown {key} {value}")
+        out[rdf_key] = value
+    return out
+
+
+def build_ontology() -> dict[str, Any]:
+    projection = load_projection()
+    _assert_edge_coverage(projection)
+    _assert_class_coverage(projection)
+    namespace = projection["namespace"]
+    root = projection["rootClass"]
+    root_id = root["id"]
+    classes = {
+        root_id: {
+            "uri": f"{namespace}{root_id}",
+            "type": "owl:Class",
+            "rdfs:label": _label(root["label"]),
+            "rdfs:comment": root["comment"],
+            "dcterms:identifier": root_id,
+        }
+    }
+    for label in schema.NODE_MODELS:
+        cls_spec = projection["classes"][label]
+        classes[label] = {
+            "uri": f"{namespace}{label}",
+            "type": "owl:Class",
+            "rdfs:label": _label(cls_spec.get("label", label)),
+            "rdfs:comment": cls_spec["comment"],
+            "rdfs:subClassOf": root_id,
+            "dcterms:identifier": label,
+        }
+
+    object_properties = {
+        prop_id: _object_property(namespace, prop_id, spec, set(classes))
+        for prop_id, spec in projection["objectProperties"].items()
+    }
+    datatype_properties = {
+        prop_id: {
+            "uri": f"{namespace}{prop_id}",
+            "type": "owl:DatatypeProperty",
+            "rdfs:label": _label(spec["label"]),
+            "rdfs:comment": f"Extraction property for canonical field {spec['field']}.",
+            "rdfs:range": spec["range"],
+        }
+        for prop_id, spec in projection["datatypeProperties"].items()
+    }
+    return {
+        "metadata": {
+            "id": projection["ontologyId"],
+            "name": projection["name"],
+            "namespace": namespace,
+            "description": projection["description"],
+            "schemaVersion": schema.SCHEMA_VERSION,
+            "projectionVersion": projection["projectionVersion"],
+        },
+        "classes": classes,
+        "objectProperties": object_properties,
+        "datatypeProperties": datatype_properties,
+    }
+
+
+def render_ontology(ontology: dict[str, Any]) -> str:
+    return json.dumps(ontology, indent=2) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    text = render_ontology(build_ontology())
+    if not args.check:
+        ONTOLOGY_PATH.write_text(text, encoding="utf-8")
+        print(f"[trustgraph-ontology] wrote {ONTOLOGY_PATH}")
+        return 0
+    if not ONTOLOGY_PATH.exists():
+        print(f"{ONTOLOGY_PATH} is missing", file=sys.stderr)
+        return 1
+    current = ONTOLOGY_PATH.read_text(encoding="utf-8")
+    if current == text:
+        print(f"[trustgraph-ontology] OK: {ONTOLOGY_PATH}")
+        return 0
+    diff = difflib.unified_diff(
+        current.splitlines(keepends=True),
+        text.splitlines(keepends=True),
+        fromfile=str(ONTOLOGY_PATH),
+        tofile="generated",
+    )
+    sys.stderr.writelines(diff)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_trustgraph_ontology.py
+++ b/tests/test_trustgraph_ontology.py
@@ -1,0 +1,140 @@
+import json
+import sys
+import unittest
+from pathlib import Path
+
+from poc_v1.ontology import schema
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GENERATOR_PATH = ROOT / "scripts" / "generate_trustgraph_ontology.py"
+ONTOLOGY_PATH = ROOT / "poc_v1" / "ontology" / "trustgraph_ontology.json"
+POLYMORPHIC_PROPERTIES = {"about", "hasLevel", "supports", "consumed"}
+
+
+def load_generator():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "generate_trustgraph_ontology",
+        GENERATOR_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class TrustGraphOntologyProjectionTest(unittest.TestCase):
+    def test_generated_classes_match_canonical_nodes_plus_root(self):
+        ontology = load_generator().build_ontology()
+
+        self.assertEqual("1.3.1", ontology["metadata"]["schemaVersion"])
+        self.assertIn("SizzlEntity", ontology["classes"])
+        self.assertEqual(
+            set(schema.NODE_MODELS) | {"SizzlEntity"},
+            set(ontology["classes"]),
+        )
+        for label in schema.NODE_MODELS:
+            self.assertEqual(
+                "SizzlEntity",
+                ontology["classes"][label]["rdfs:subClassOf"],
+            )
+
+    def test_object_properties_represent_every_canonical_edge_once(self):
+        generator = load_generator()
+        ontology = generator.build_ontology()
+        projection = generator.load_projection()
+        edge_to_property = {
+            spec["edgeLabel"]: prop_id
+            for prop_id, spec in projection["objectProperties"].items()
+        }
+
+        self.assertEqual(set(schema.EDGE_MODELS), set(edge_to_property))
+        self.assertEqual(set(edge_to_property.values()), set(ontology["objectProperties"]))
+
+    def test_polymorphic_properties_do_not_emit_domain_or_range(self):
+        ontology = load_generator().build_ontology()
+
+        for prop_id in POLYMORPHIC_PROPERTIES:
+            prop = ontology["objectProperties"][prop_id]
+            self.assertNotIn("rdfs:domain", prop)
+            self.assertNotIn("rdfs:range", prop)
+
+    def test_datatype_properties_are_the_extraction_subset(self):
+        ontology = load_generator().build_ontology()
+
+        self.assertEqual(
+            {
+                "sizzlId",
+                "name",
+                "definition",
+                "schemaVersion",
+                "validFrom",
+                "validTo",
+                "confidence",
+                "sourceRef",
+                "sourceUrl",
+                "extractedClaim",
+            },
+            set(ontology["datatypeProperties"]),
+        )
+
+    def test_checked_in_artifact_matches_generator(self):
+        generator = load_generator()
+        expected = generator.render_ontology(generator.build_ontology())
+
+        self.assertEqual(expected, ONTOLOGY_PATH.read_text(encoding="utf-8"))
+
+    def test_class_projection_roster_matches_canonical_nodes(self):
+        """Every Pydantic node model needs a projection.classes entry with
+        label + comment. Adding/removing a model must force a projection
+        update so RAG-side class metadata can't silently drift from the
+        canonical schema. See sizzl-trustgraph#39."""
+        generator = load_generator()
+        projection = generator.load_projection()
+
+        self.assertIn("classes", projection)
+        self.assertEqual(
+            set(schema.NODE_MODELS),
+            set(projection["classes"]),
+        )
+        for label, spec in projection["classes"].items():
+            self.assertIn("label", spec, f"{label} missing 'label'")
+            self.assertIn("comment", spec, f"{label} missing 'comment'")
+            self.assertTrue(spec["comment"], f"{label} comment is empty")
+            self.assertNotEqual(
+                spec["comment"],
+                f"Canonical Sizzl {label} entity.",
+                f"{label} still has the placeholder comment — needs real prose",
+            )
+
+    def test_generated_ontology_loads_in_trustgraph_loader(self):
+        checkout = ROOT.parent / "causl.io.sizzle" / "trustgraph" / "trustgraph-flow"
+        if not checkout.exists():
+            self.skipTest("TrustGraph checkout not available")
+
+        import importlib.util
+
+        loader_path = (
+            checkout / "trustgraph" / "extract" / "kg" / "ontology" / "ontology_loader.py"
+        )
+        spec = importlib.util.spec_from_file_location(
+            "trustgraph_ontology_loader",
+            loader_path,
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        loader = module.OntologyLoader()
+        ontology = json.loads(ONTOLOGY_PATH.read_text(encoding="utf-8"))
+        loader.update_ontologies({"sizzl-market-v1": ontology})
+        loaded = loader.get_ontology("sizzl-market-v1")
+
+        self.assertIsNotNone(loaded)
+        self.assertEqual([], loaded.validate_structure())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Closes
[sizzl-trustgraph#39](https://github.com/Subconscious-ai/sizzl-trustgraph/issues/39) — eliminates the silent drift between this repo's canonical schema and the hand-maintained TrustGraph artifact in sizzl-trustgraph.

## What ships

| File | Status | Purpose |
|---|---|---|
| `poc_v1/ontology/trustgraph_projection.json` | new | Projection config — namespace, rootClass, **classes** (new block with label + rich comment per Pydantic NODE_MODELS), objectProperties, datatypeProperties |
| `scripts/generate_trustgraph_ontology.py` | new | Reads schema.NODE_MODELS + projection → emits OWL-shaped JSON. Fails loud on roster drift |
| `poc_v1/ontology/trustgraph_ontology.json` | new | Generated artifact (478 lines, sha256 `db9c5011...`) — **byte-identical** to sizzl-trustgraph's hand-curated copy |
| `tests/test_trustgraph_ontology.py` | new | 7 tests including class-roster drift check |

## Why rich comments matter

The `rdfs:comment` strings are LLM extraction prompts in disguise. The Sizzl-tuned `kg-extract-ontology` worker uses them as in-context disambiguation hints when typing instances. The prior placeholder `Canonical Sizzl X entity.` stripped the extraction guidance. Real prose with concrete examples makes the extractor land more typed instances and fewer ambiguous URIs.

Before / after for `Market`:

```
- "Canonical Sizzl Market entity."
+ "A bounded competitive space in which Companies offer Offerings to
+  StakeholderArchetypes — e.g. the smartphone market, the AI-platform
+  market, the at-home baking market."
```

13 classes × similar deltas. The full prose was previously hand-maintained in sizzl-trustgraph at \`packages/trustgraph-config/artifacts/sizzl-market-v1.ontology.json\` (478 lines, sha256 `db9c5011...`). With this PR, the same content is the **generated output** — single source of truth.

## Why projection.classes, not schema.py docstrings

Two viable places to encode class prose:

| Option | Source | Tradeoff |
|---|---|---|
| **A. projection.classes (chosen)** | `trustgraph_projection.json` | Mirrors the existing `objectProperties` pattern in the same file. Decouples projection-config from Pydantic validation. Keeps schema.py focused on field validation. |
| B. schema.py class docstrings | Pydantic `__doc__` | Conflates LLM-prompt prose with code documentation. Existing docstrings would need to be rewritten in a specific format. |

**Karpathy Rule 11**: match the codebase's convention. `objectProperties` already lives in projection.json with `comment` fields; classes follow the same pattern.

## Drift safety (Karpathy Rule 12: fail loud)

New `_assert_class_coverage()` runs at generator entry:

```python
expected = set(schema.NODE_MODELS)
actual = set(projection.get("classes", {}))
if expected != actual:
    raise SystemExit(f"missing={sorted(expected - actual)} extra={sorted(actual - expected)}")
```

Negative test verified: deleting `Market` from projection.classes → test fails with `AssertionError: Items in the first set but not the second: 'Market'`.

## Validation

```
=== Full test pass ===
$ python3 -m pytest tests/ -q
120 passed, 51 subtests passed in 1.22s

=== Generator output is byte-identical to sizzl-trustgraph hand-curated ===
$ shasum -a 256 poc_v1/ontology/trustgraph_ontology.json
db9c5011d04d905c4dfdcaf77499f9052d3aa5e0518ecd2308b8b0ab19b7eb3c

$ shasum -a 256 /path/to/sizzl-trustgraph/packages/trustgraph-config/artifacts/sizzl-market-v1.ontology.json
db9c5011d04d905c4dfdcaf77499f9052d3aa5e0518ecd2308b8b0ab19b7eb3c

$ diff poc_v1/ontology/trustgraph_ontology.json \
       /path/to/sizzl-trustgraph/packages/trustgraph-config/artifacts/sizzl-market-v1.ontology.json
(no output — files are identical)
```

## Followup in sizzl-trustgraph

After this lands:
1. sizzl-trustgraph replaces its hand-maintained file with a mirror of this generator's output
2. Adds a doc-rot CI test that fails if its mirrored artifact's sha256 differs from upstream
3. `packages/trustgraph-config/README.md` regen command points at this generator (not the lie it currently has)

🤖 Generated with [Claude Code](https://claude.com/claude-code)