### PR TITLE
feat(ontology): v1.4.0 — Continuant-Continuant edges + Person sortal

### DIFF
--- a/poc_v1/MIGRATION.md
+++ b/poc_v1/MIGRATION.md
@@ -1,6 +1,51 @@
-# Migration — v0 to v1 (and v1.0 → v1.3.1)
+# Migration — v0 to v1 (and v1.0 → v1.4.0)
 
 This document records what changed between the initial POC scaffolding and the v1 ontology, and why. Keep this file. Future schema migrations should follow the same pattern.
+
+## v1.3.1 → v1.4.0 (2026-05-13) — Continuant-Continuant edges + Person sortal
+
+**Additive.** All v1.3.1 records continue to validate. `SCHEMA_VERSION` bumped `1.3.1 → 1.4.0`.
+
+### Change
+
+**New nodes:**
+- `Person` (sortal, +R+I) — natural person who plays one or more `StakeholderArchetype` roles. Resolves the OntoClean role-as-sortal violation: `StakeholderArchetype` is anti-rigid (a role); `Person` is the rigid entity that plays it. Opt-in for projection consumers (Twenty/SuperEgo) until same-person-multiple-roles emerges at scale.
+
+**New edges (Continuant-to-Continuant):**
+
+| Edge | from → to | What it captures |
+|---|---|---|
+| `COMPETES_WITH` | Company → Company | Direct competitive structure. Symmetric in practice. |
+| `PARTNERED_WITH` | Company → Company | Strategic alliance, channel, JV, supplier. |
+| `ACQUIRED` | Company → Company | M&A. `acquired_at` for the close date, `price` if disclosed. |
+| `PRODUCED_BY` | Offering → Company | Inverse of `OFFERED_BY`. LLM emits this direction naturally. |
+| `ALTERNATIVE_TO` | Offering → Offering | Functional substitute. Foundational for choice-set construction. |
+| `COMPLEMENT_OF` | Offering → Offering | Bundle / ecosystem complement. |
+| `PLAYS` | Person → StakeholderArchetype | v1.4.0 role-binding (Person plays Archetype role). |
+
+**Extended `Company` props (optional):**
+- `industry` (schema.org-aligned Organization.industry)
+- `headquarters` (free-form for v1, structured location in v2)
+- `ticker` (public stock ticker)
+- `_TemporallyValid` mixin (companies wind down, merge, rebrand)
+
+### Why
+
+Substrate hygiene diagnostic in [sizzl-trustgraph#181](https://github.com/Subconscious-ai/sizzl-trustgraph/issues/181) found that LLM extractors emit these predicates ~136 times across 423 chunks, all silently dropped because no matching object property was declared. Specifically: `competesWith`, `competitorOf`, `partnersWith`, `alternativeTo`, `acquired`. By promoting these to typed first-class edges, the substrate captures the competitive structure that downstream graph_rag and SPARQL queries need.
+
+Per OntoClean (Guarino & Welty), introducing `Person` resolves the rigidity/identity mismatch in `StakeholderArchetype`: archetypes are roles (~R+D), persons are sortals (+R+I). The two-layer model is consistent with ontology engineering literature and unblocks future "same individual, multiple roles" use cases.
+
+### Triggering conditions met (from v2_spec.md)
+
+- "Competitor analysis becomes a first-class deliverable" — yes, executives are asking for competitive synthesis in Sizzl reports.
+- "You want to track M&A, rebrandings, parent/child corporate structure" — yes, ACQUIRED edge ships this.
+
+### Non-goals (still v2 parking)
+
+- `QualityValue` consolidation of `Attribute`+`AttributeLevel` into one node.
+- `Claim` as separate from `Evidence` (multi-evidence-per-claim).
+- `ContextFactor` as a first-class node.
+- Causal edges (`CAUSES`, `HAS_TREATMENT`, etc.) — still rejected.
 
 ## v1.3.0 → v1.3.1 (2026-05-05) — harden causal projection contracts
 

--- a/poc_v1/contracts/examples/lighthouse_projection_pack.skeleton.json
+++ b/poc_v1/contracts/examples/lighthouse_projection_pack.skeleton.json
@@ -3,7 +3,7 @@
   "fixture_version": "0.1.0",
   "source_of_record": "twenty",
   "input_filter": "accepted_only",
-  "ontology_schema_version": "1.3.1",
+  "ontology_schema_version": "1.4.0",
   "projection_version": "0.1.0",
   "snapshot_hash": "sha256:lighthouse-skeleton",
   "projection_timestamp": "2026-05-09T00:00:00Z",

--- a/poc_v1/ontology/edge_schemas.json
+++ b/poc_v1/ontology/edge_schemas.json
@@ -1,108 +1,374 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "v1 POC Edge Schemas",
-  "schema_version": "1.3.1",
+  "schema_version": "1.4.0",
   "type": "object",
   "properties": {
     "FROM": {
       "from": "Transition",
       "to": "Stage",
       "properties": {
-        "schema_version": {"type": "string"}
+        "schema_version": {
+          "type": "string"
+        }
       }
     },
     "TO": {
       "from": "Transition",
       "to": "Stage",
       "properties": {
-        "schema_version": {"type": "string"}
+        "schema_version": {
+          "type": "string"
+        }
       }
     },
     "IN_MARKET": {
       "from": "Transition",
       "to": "Market",
       "properties": {
-        "schema_version": {"type": "string"}
+        "schema_version": {
+          "type": "string"
+        }
       }
     },
     "RELEVANT_TO": {
       "from": "Transition",
       "to": "StakeholderArchetype",
       "properties": {
-        "confidence": {"type": ["number", "null"], "minimum": 0.0, "maximum": 1.0},
-        "schema_version": {"type": "string"}
+        "confidence": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "schema_version": {
+          "type": "string"
+        }
       }
     },
     "ABOUT": {
-      "from": ["Transition", "Estimate"],
+      "from": [
+        "Transition",
+        "Estimate"
+      ],
       "to": "*",
       "properties": {
-        "target_node_type": {"type": ["string", "null"]},
-        "schema_version": {"type": "string"}
+        "target_node_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schema_version": {
+          "type": "string"
+        }
       }
     },
     "HAS_ATTRIBUTE": {
       "from": "Offering",
       "to": "Attribute",
       "properties": {
-        "schema_version": {"type": "string"}
+        "schema_version": {
+          "type": "string"
+        }
       }
     },
     "HAS_LEVEL": {
-      "from": ["Attribute", "Trait"],
-      "to": ["AttributeLevel", "TraitLevel"],
+      "from": [
+        "Attribute",
+        "Trait"
+      ],
+      "to": [
+        "AttributeLevel",
+        "TraitLevel"
+      ],
       "properties": {
-        "schema_version": {"type": "string"}
+        "schema_version": {
+          "type": "string"
+        }
       }
     },
     "HAS_TRAIT": {
       "from": "StakeholderArchetype",
       "to": "Trait",
       "properties": {
-        "schema_version": {"type": "string"}
+        "schema_version": {
+          "type": "string"
+        }
       }
     },
     "RELEVANT_AT": {
       "from": "Attribute",
       "to": "Stage",
       "properties": {
-        "score": {"type": "number", "minimum": 0.0, "maximum": 1.0},
-        "valid_from": {"type": ["string", "null"], "format": "date"},
-        "valid_to": {"type": ["string", "null"], "format": "date"},
-        "evidence_ids": {"type": "array", "items": {"type": "string"}},
-        "schema_version": {"type": "string"}
+        "score": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "valid_from": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "valid_to": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "evidence_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "schema_version": {
+          "type": "string"
+        }
       }
     },
     "SUPPORTS": {
       "from": "Evidence",
       "to": "*",
       "properties": {
-        "target_node_type": {"type": ["string", "null"]},
-        "confidence": {"type": ["number", "null"], "minimum": 0.0, "maximum": 1.0},
-        "support_type": {"type": ["string", "null"]},
-        "schema_version": {"type": "string"}
+        "target_node_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "confidence": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "support_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schema_version": {
+          "type": "string"
+        }
       }
     },
     "OFFERED_BY": {
       "from": "Offering",
       "to": "Company",
       "properties": {
-        "schema_version": {"type": "string"}
+        "schema_version": {
+          "type": "string"
+        }
       }
     },
     "CONSUMED": {
       "from": "ExperimentRun",
       "to": "*",
       "properties": {
-        "target_node_type": {"type": ["string", "null"]},
-        "schema_version": {"type": "string"}
+        "target_node_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schema_version": {
+          "type": "string"
+        }
       }
     },
     "PRODUCED": {
       "from": "ExperimentRun",
       "to": "Estimate",
       "properties": {
-        "schema_version": {"type": "string"}
+        "schema_version": {
+          "type": "string"
+        }
+      }
+    },
+    "COMPETES_WITH": {
+      "from": "Company",
+      "to": "Company",
+      "properties": {
+        "confidence": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "evidence_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "valid_from": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "valid_to": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "schema_version": {
+          "type": "string"
+        }
+      }
+    },
+    "PARTNERED_WITH": {
+      "from": "Company",
+      "to": "Company",
+      "properties": {
+        "partnership_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "confidence": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "valid_from": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "valid_to": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "schema_version": {
+          "type": "string"
+        }
+      }
+    },
+    "ACQUIRED": {
+      "from": "Company",
+      "to": "Company",
+      "properties": {
+        "acquired_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "price": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "confidence": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "schema_version": {
+          "type": "string"
+        }
+      }
+    },
+    "PRODUCED_BY": {
+      "from": "Offering",
+      "to": "Company",
+      "properties": {
+        "schema_version": {
+          "type": "string"
+        }
+      }
+    },
+    "ALTERNATIVE_TO": {
+      "from": "Offering",
+      "to": "Offering",
+      "properties": {
+        "similarity_score": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "schema_version": {
+          "type": "string"
+        }
+      }
+    },
+    "COMPLEMENT_OF": {
+      "from": "Offering",
+      "to": "Offering",
+      "properties": {
+        "bundle_strength": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "schema_version": {
+          "type": "string"
+        }
+      }
+    },
+    "PLAYS": {
+      "from": "Person",
+      "to": "StakeholderArchetype",
+      "properties": {
+        "role_context": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "valid_from": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "valid_to": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "schema_version": {
+          "type": "string"
+        }
       }
     }
   }

--- a/poc_v1/ontology/kg_seed_contract.json
+++ b/poc_v1/ontology/kg_seed_contract.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.3.1",
+  "schema_version": "1.4.0",
   "nodes": {
     "Market": {
       "filename": "markets.jsonl",
@@ -16,6 +16,10 @@
     "StakeholderArchetype": {
       "filename": "stakeholder_archetypes.jsonl",
       "graph_type": "stakeholder"
+    },
+    "Person": {
+      "filename": "persons.jsonl",
+      "graph_type": "person"
     },
     "Offering": {
       "filename": "offerings.jsonl",
@@ -169,6 +173,62 @@
       ],
       "from": "ExperimentRun",
       "to": "Estimate"
+    },
+    "COMPETES_WITH": {
+      "filename": "edges_company_competes_with.jsonl",
+      "filenames": [
+        "edges_company_competes_with.jsonl"
+      ],
+      "from": "Company",
+      "to": "Company"
+    },
+    "PARTNERED_WITH": {
+      "filename": "edges_company_partnered_with.jsonl",
+      "filenames": [
+        "edges_company_partnered_with.jsonl"
+      ],
+      "from": "Company",
+      "to": "Company"
+    },
+    "ACQUIRED": {
+      "filename": "edges_company_acquired.jsonl",
+      "filenames": [
+        "edges_company_acquired.jsonl"
+      ],
+      "from": "Company",
+      "to": "Company"
+    },
+    "PRODUCED_BY": {
+      "filename": "edges_offering_produced_by.jsonl",
+      "filenames": [
+        "edges_offering_produced_by.jsonl"
+      ],
+      "from": "Offering",
+      "to": "Company"
+    },
+    "ALTERNATIVE_TO": {
+      "filename": "edges_offering_alternative_to.jsonl",
+      "filenames": [
+        "edges_offering_alternative_to.jsonl"
+      ],
+      "from": "Offering",
+      "to": "Offering"
+    },
+    "COMPLEMENT_OF": {
+      "filename": "edges_offering_complement_of.jsonl",
+      "filenames": [
+        "edges_offering_complement_of.jsonl"
+      ],
+      "from": "Offering",
+      "to": "Offering"
+    },
+    "PLAYS": {
+      "filename": "edges_person_plays.jsonl",
+      "filenames": [
+        "edges_person_plays.jsonl"
+      ],
+      "from": "Person",
+      "to": "StakeholderArchetype"
     }
   },
   "files": {
@@ -283,6 +343,38 @@
     "edges_experiment_run_produced.jsonl": {
       "kind": "edge",
       "label": "PRODUCED"
+    },
+    "persons.jsonl": {
+      "kind": "node",
+      "label": "Person"
+    },
+    "edges_company_competes_with.jsonl": {
+      "kind": "edge",
+      "label": "COMPETES_WITH"
+    },
+    "edges_company_partnered_with.jsonl": {
+      "kind": "edge",
+      "label": "PARTNERED_WITH"
+    },
+    "edges_company_acquired.jsonl": {
+      "kind": "edge",
+      "label": "ACQUIRED"
+    },
+    "edges_offering_produced_by.jsonl": {
+      "kind": "edge",
+      "label": "PRODUCED_BY"
+    },
+    "edges_offering_alternative_to.jsonl": {
+      "kind": "edge",
+      "label": "ALTERNATIVE_TO"
+    },
+    "edges_offering_complement_of.jsonl": {
+      "kind": "edge",
+      "label": "COMPLEMENT_OF"
+    },
+    "edges_person_plays.jsonl": {
+      "kind": "edge",
+      "label": "PLAYS"
     }
   }
 }

--- a/poc_v1/ontology/node_schemas.json
+++ b/poc_v1/ontology/node_schemas.json
@@ -1,177 +1,533 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "v1 POC Node Schemas",
-  "schema_version": "1.3.1",
+  "schema_version": "1.4.0",
   "type": "object",
   "properties": {
     "Market": {
       "type": "object",
-      "required": ["id", "name", "definition"],
+      "required": [
+        "id",
+        "name",
+        "definition"
+      ],
       "properties": {
-        "id": {"type": "string"},
-        "name": {"type": "string"},
-        "definition": {"type": "string"},
-        "geography": {"type": ["string", "null"]},
-        "industry_codes": {"type": "array", "items": {"type": "string"}},
-        "context_factors": {"type": "object"},
-        "period": {"type": ["string", "null"]},
-        "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "definition": {
+          "type": "string"
+        },
+        "geography": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "industry_codes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "context_factors": {
+          "type": "object"
+        },
+        "period": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "ingested_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
       },
       "additionalProperties": false
     },
     "Stage": {
       "type": "object",
-      "required": ["id", "name", "definition"],
+      "required": [
+        "id",
+        "name",
+        "definition"
+      ],
       "properties": {
-        "id": {"type": "string"},
+        "id": {
+          "type": "string"
+        },
         "name": {
           "type": "string",
-          "enum": ["awareness", "acquisition", "activation", "retention", "referral", "revenue"]
+          "enum": [
+            "awareness",
+            "acquisition",
+            "activation",
+            "retention",
+            "referral",
+            "revenue"
+          ]
         },
-        "definition": {"type": "string"},
-        "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "definition": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "ingested_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
       },
       "additionalProperties": false
     },
     "Transition": {
       "type": "object",
-      "required": ["id", "name", "from_stage_id", "to_stage_id", "definition"],
+      "required": [
+        "id",
+        "name",
+        "from_stage_id",
+        "to_stage_id",
+        "definition"
+      ],
       "properties": {
-        "id": {"type": "string"},
-        "name": {"type": "string"},
-        "from_stage_id": {"type": "string"},
-        "to_stage_id": {"type": "string"},
-        "definition": {"type": "string"},
-        "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "from_stage_id": {
+          "type": "string"
+        },
+        "to_stage_id": {
+          "type": "string"
+        },
+        "definition": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "ingested_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
       },
       "additionalProperties": false
     },
     "StakeholderArchetype": {
       "type": "object",
-      "required": ["id", "name", "archetype_type"],
+      "required": [
+        "id",
+        "name",
+        "archetype_type"
+      ],
       "properties": {
-        "id": {"type": "string"},
-        "name": {"type": "string"},
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
         "archetype_type": {
           "type": "string",
-          "enum": ["customer", "competitor_buyer", "competitor_user"]
+          "enum": [
+            "customer",
+            "competitor_buyer",
+            "competitor_user"
+          ]
         },
-        "traits": {"type": "object"},
-        "role": {"type": ["string", "null"]},
-        "segment": {"type": ["string", "null"]},
-        "industry": {"type": ["string", "null"]},
-        "company_size_band": {"type": ["string", "null"]},
-        "definition": {"type": ["string", "null"]},
-        "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "traits": {
+          "type": "object"
+        },
+        "role": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "segment": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "industry": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "company_size_band": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "definition": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "ingested_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
       },
       "additionalProperties": false
     },
     "Offering": {
       "type": "object",
-      "required": ["id", "name", "company_name"],
+      "required": [
+        "id",
+        "name",
+        "company_name"
+      ],
       "properties": {
-        "id": {"type": "string"},
-        "name": {"type": "string"},
-        "company_name": {"type": "string"},
-        "is_competitor": {"type": "boolean"},
-        "category": {"type": ["string", "null"]},
-        "definition": {"type": ["string", "null"]},
-        "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "company_name": {
+          "type": "string"
+        },
+        "is_competitor": {
+          "type": "boolean"
+        },
+        "category": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "definition": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "ingested_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
       },
       "additionalProperties": false
     },
     "Attribute": {
       "type": "object",
-      "required": ["id", "name", "data_type", "definition"],
+      "required": [
+        "id",
+        "name",
+        "data_type",
+        "definition"
+      ],
       "properties": {
-        "id": {"type": "string"},
-        "name": {"type": "string"},
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
         "data_type": {
           "type": "string",
-          "enum": ["continuous", "ordinal", "categorical", "boolean"]
+          "enum": [
+            "continuous",
+            "ordinal",
+            "categorical",
+            "boolean"
+          ]
         },
-        "unit": {"type": ["string", "null"]},
-        "definition": {"type": "string"},
-        "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "unit": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "definition": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "ingested_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
       },
       "additionalProperties": false
     },
     "AttributeLevel": {
       "type": "object",
-      "required": ["id", "attribute_id", "market_id", "value"],
+      "required": [
+        "id",
+        "attribute_id",
+        "market_id",
+        "value"
+      ],
       "properties": {
-        "id": {"type": "string"},
-        "attribute_id": {"type": "string"},
-        "market_id": {"type": "string"},
+        "id": {
+          "type": "string"
+        },
+        "attribute_id": {
+          "type": "string"
+        },
+        "market_id": {
+          "type": "string"
+        },
         "value": {},
-        "label": {"type": ["string", "null"]},
-        "is_status_quo": {"type": "boolean"},
-        "valid_from": {"type": ["string", "null"], "format": "date"},
-        "valid_to": {"type": ["string", "null"], "format": "date"},
-        "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "is_status_quo": {
+          "type": "boolean"
+        },
+        "valid_from": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "valid_to": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "ingested_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
       },
       "additionalProperties": false
     },
     "Trait": {
       "type": "object",
-      "required": ["id", "name", "data_type", "definition"],
+      "required": [
+        "id",
+        "name",
+        "data_type",
+        "definition"
+      ],
       "properties": {
-        "id": {"type": "string"},
-        "name": {"type": "string"},
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
         "data_type": {
           "type": "string",
-          "enum": ["continuous", "ordinal", "categorical", "boolean"]
+          "enum": [
+            "continuous",
+            "ordinal",
+            "categorical",
+            "boolean"
+          ]
         },
-        "unit": {"type": ["string", "null"]},
-        "definition": {"type": "string"},
-        "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "unit": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "definition": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "ingested_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
       },
       "additionalProperties": false
     },
     "TraitLevel": {
       "type": "object",
-      "required": ["id", "trait_id", "market_id", "value"],
+      "required": [
+        "id",
+        "trait_id",
+        "market_id",
+        "value"
+      ],
       "properties": {
-        "id": {"type": "string"},
-        "trait_id": {"type": "string"},
-        "market_id": {"type": "string"},
+        "id": {
+          "type": "string"
+        },
+        "trait_id": {
+          "type": "string"
+        },
+        "market_id": {
+          "type": "string"
+        },
         "value": {},
-        "label": {"type": ["string", "null"]},
-        "is_status_quo": {"type": "boolean"},
-        "valid_from": {"type": ["string", "null"], "format": "date"},
-        "valid_to": {"type": ["string", "null"], "format": "date"},
-        "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "is_status_quo": {
+          "type": "boolean"
+        },
+        "valid_from": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "valid_to": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "ingested_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
       },
       "additionalProperties": false
     },
     "Evidence": {
       "type": "object",
-      "required": ["id", "source_type", "source_ref"],
+      "required": [
+        "id",
+        "source_type",
+        "source_ref"
+      ],
       "properties": {
-        "id": {"type": "string"},
+        "id": {
+          "type": "string"
+        },
         "source_type": {
           "type": "string",
-          "enum": ["s1", "10k", "interview", "survey", "benchmark", "web", "deck", "executive_interview", "research_agent"]
+          "enum": [
+            "s1",
+            "10k",
+            "interview",
+            "survey",
+            "benchmark",
+            "web",
+            "deck",
+            "executive_interview",
+            "research_agent"
+          ]
         },
-        "source_ref": {"type": "string"},
-        "source_url": {"type": ["string", "null"]},
-        "excerpt": {"type": ["string", "null"]},
-        "extracted_claim": {"type": ["string", "null"]},
-        "retrieval_query": {"type": ["string", "null"]},
-        "extractor_version": {"type": ["string", "null"]},
-        "confidence": {"type": ["number", "null"], "minimum": 0.0, "maximum": 1.0},
-        "period_observed": {"type": ["string", "null"]},
-        "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "source_ref": {
+          "type": "string"
+        },
+        "source_url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "excerpt": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "extracted_claim": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "retrieval_query": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "extractor_version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "confidence": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "period_observed": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "ingested_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
       },
       "additionalProperties": false
     },
@@ -187,82 +543,371 @@
         "estimated_at"
       ],
       "properties": {
-        "id": {"type": "string"},
+        "id": {
+          "type": "string"
+        },
         "estimate_type": {
           "type": "string",
-          "enum": ["part_worth", "transition_probability", "wtp", "elasticity", "ate", "amce", "importance"]
+          "enum": [
+            "part_worth",
+            "transition_probability",
+            "wtp",
+            "elasticity",
+            "ate",
+            "amce",
+            "importance"
+          ]
         },
-        "value": {"type": "number"},
-        "ci_low": {"type": ["number", "null"]},
-        "ci_high": {"type": ["number", "null"]},
-        "standard_error": {"type": ["number", "null"]},
-        "subconscious_experiment_id": {"type": "string"},
-        "model_version": {"type": "string"},
-        "ontology_snapshot_hash": {"type": "string"},
-        "estimated_at": {"type": "string", "format": "date-time"},
-        "valid_from": {"type": ["string", "null"], "format": "date"},
-        "valid_to": {"type": ["string", "null"], "format": "date"},
-        "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "value": {
+          "type": "number"
+        },
+        "ci_low": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "ci_high": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "standard_error": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "subconscious_experiment_id": {
+          "type": "string"
+        },
+        "model_version": {
+          "type": "string"
+        },
+        "ontology_snapshot_hash": {
+          "type": "string"
+        },
+        "estimated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "valid_from": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "valid_to": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "ingested_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
       },
       "additionalProperties": false
     },
     "Company": {
       "type": "object",
-      "required": ["id", "name"],
+      "required": [
+        "id",
+        "name"
+      ],
       "properties": {
-        "id": {"type": "string"},
-        "name": {"type": "string"},
-        "domain": {"type": ["string", "null"]},
-        "definition": {"type": ["string", "null"]},
-        "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "domain": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "definition": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "ingested_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "industry": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "headquarters": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ticker": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "valid_from": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "valid_to": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        }
       },
       "additionalProperties": false
     },
     "ExperimentRun": {
       "type": "object",
-      "required": ["id", "ontology_snapshot_hash", "status"],
+      "required": [
+        "id",
+        "ontology_snapshot_hash",
+        "status"
+      ],
       "properties": {
-        "id": {"type": "string"},
-        "ontology_snapshot_hash": {"type": "string"},
-        "super_ego_run_id": {"type": ["string", "null"]},
-        "wandb_entity": {"type": ["string", "null"]},
-        "wandb_project": {"type": ["string", "null"]},
-        "wandb_run_id": {"type": ["string", "null"]},
-        "wandb_run_name": {"type": ["string", "null"]},
+        "id": {
+          "type": "string"
+        },
+        "ontology_snapshot_hash": {
+          "type": "string"
+        },
+        "super_ego_run_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wandb_entity": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wandb_project": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wandb_run_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wandb_run_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "status": {
           "type": "string",
-          "enum": ["pending", "running", "finished", "failed", "cancelled"]
+          "enum": [
+            "pending",
+            "running",
+            "finished",
+            "failed",
+            "cancelled"
+          ]
         },
-        "artifact_refs": {"type": "array", "items": {"type": "string"}},
+        "artifact_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "wandb_artifacts": {
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["entity", "project", "name", "type", "version", "digest"],
+            "required": [
+              "entity",
+              "project",
+              "name",
+              "type",
+              "version",
+              "digest"
+            ],
             "properties": {
-              "entity": {"type": "string"},
-              "project": {"type": "string"},
-              "run_id": {"type": ["string", "null"]},
-              "name": {"type": "string"},
-              "type": {"type": "string"},
-              "version": {"type": "string"},
-              "digest": {"type": "string"},
-              "qualified_name": {"type": ["string", "null"]},
-              "aliases": {"type": "array", "items": {"type": "string"}},
-              "url": {"type": ["string", "null"]},
-              "files": {"type": "array", "items": {"type": "object"}}
+              "entity": {
+                "type": "string"
+              },
+              "project": {
+                "type": "string"
+              },
+              "run_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              },
+              "digest": {
+                "type": "string"
+              },
+              "qualified_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "aliases": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "url": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "files": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
             },
             "additionalProperties": false
           }
         },
-        "model_versions": {"type": "object", "additionalProperties": {"type": "string"}},
-        "sample_size": {"type": ["integer", "null"]},
-        "started_at": {"type": ["string", "null"], "format": "date-time"},
-        "completed_at": {"type": ["string", "null"], "format": "date-time"},
-        "schema_version": {"type": "string"},
-        "ingested_at": {"type": ["string", "null"], "format": "date-time"}
+        "model_versions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "sample_size": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "started_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "completed_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "ingested_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Person": {
+      "type": "object",
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "role_title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "company_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "definition": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "valid_from": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "valid_to": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "ingested_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
       },
       "additionalProperties": false
     }

--- a/poc_v1/ontology/schema.py
+++ b/poc_v1/ontology/schema.py
@@ -7,7 +7,17 @@ This is the single source of truth for the schema. Keep it aligned with:
   - ontology/edge_schemas.json
   - graph-store adapter constraints/import scripts
 
-Schema version: 1.3.1
+Schema version: 1.4.0 — see MIGRATION.md for what changed from 1.3.1.
+
+v1.4.0 adds Continuant-to-Continuant primitives (competesWith, partneredWith,
+acquired, producedBy, alternativeTo, complementOf, plays) and a new Person
+sortal that plays the StakeholderArchetype role. Motivated by the substrate
+hygiene diagnostic in sizzl-trustgraph#181: extraction logs show the LLM
+naturally emits competesWith / competitorOf / partnersWith / alternativeTo /
+acquired ~136 times across 423 chunks, all dropped by the validator because
+these predicates were not declared.
+
+Backwards-compatible: all v1.3.1 data validates against v1.4.0 unchanged.
 """
 
 from __future__ import annotations
@@ -18,7 +28,7 @@ from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
-SCHEMA_VERSION = "1.3.1"
+SCHEMA_VERSION = "1.4.0"
 
 
 # ---------------------------------------------------------------------------
@@ -154,13 +164,43 @@ class Offering(_VersionedNode):
     definition: Optional[str] = None
 
 
-class Company(_VersionedNode):
+class Company(_VersionedNode, _TemporallyValid):
     """The organization that offers one or more Offerings. Added in v1.1 to
-    give Offering→Company a proper edge for rollup queries. Minimal props;
-    add funding/size/industry in a later bump when a consumer needs them."""
+    give Offering→Company a proper edge for rollup queries.
+
+    v1.4.0 additions:
+      - industry, headquarters, ticker (schema.org-aligned identity props)
+      - _TemporallyValid mixin (companies wind down, merge, rebrand)
+    """
     id: str
     name: str
     domain: Optional[str] = None
+    definition: Optional[str] = None
+    industry: Optional[str] = None        # v1.4.0 — schema.org Organization.industry
+    headquarters: Optional[str] = None    # v1.4.0 — city + country, free-form for v1
+    ticker: Optional[str] = None          # v1.4.0 — stock ticker if public
+
+
+class Person(_VersionedNode, _TemporallyValid):
+    """A natural person who plays one or more StakeholderArchetype roles.
+
+    Added in v1.4.0 to address the OntoClean role-as-sortal violation in
+    StakeholderArchetype: the archetype is the ROLE (anti-rigid, dependent),
+    not the entity that carries identity. Person is the +R+I sortal that
+    plays the role.
+
+    StakeholderArchetype is retained unchanged for backwards compatibility;
+    new ingests that have clear individual identity should write a Person
+    node + a PLAYS edge instead of a bare StakeholderArchetype.
+
+    Triggering condition (per v2_spec.md): scale beyond a single-customer
+    POC where the same individual plays role X at company A and role Y at
+    company B. Until that scale, Person is opt-in.
+    """
+    id: str
+    name: str
+    role_title: Optional[str] = None      # e.g. "CFO", "Head of Procurement"
+    company_id: Optional[str] = None      # backref to Company.id if known
     definition: Optional[str] = None
 
 
@@ -357,6 +397,104 @@ class EdgeProduced(_Edge):
 
 
 # ---------------------------------------------------------------------------
+# v1.4.0 — Continuant-to-Continuant primitives
+#
+# These six edges close the substrate-hygiene gap surfaced in
+# sizzl-trustgraph#181: the LLM extractor was emitting competesWith /
+# competitorOf / partnersWith / alternativeTo / acquired ~136 times across
+# 423 chunks, all silently dropped because no matching object property was
+# declared. Now they have proper homes.
+#
+# Plus one new edge (PLAYS) for the v1.4.0 Person → StakeholderArchetype
+# role-binding pattern.
+# ---------------------------------------------------------------------------
+
+
+class EdgeCompetesWith(_Edge, _TemporallyValid):
+    """Company -[:COMPETES_WITH]-> Company.
+
+    Direct competitive relationship. Symmetric in practice but stored
+    directionally — writers may emit both directions or rely on consumers
+    to handle the symmetry. Confidence is required for downstream filtering.
+    """
+    label: Literal["COMPETES_WITH"] = "COMPETES_WITH"
+    confidence: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    evidence_ids: list[str] = Field(default_factory=list)
+
+
+class EdgePartneredWith(_Edge, _TemporallyValid):
+    """Company -[:PARTNERED_WITH]-> Company.
+
+    Strategic alliance, channel partnership, JV, or co-marketing. The
+    partnership_type free-form prop captures the kind (e.g. "channel",
+    "co-marketing", "JV", "supplier"). When in doubt, leave it null.
+    """
+    label: Literal["PARTNERED_WITH"] = "PARTNERED_WITH"
+    partnership_type: Optional[str] = None
+    confidence: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+
+
+class EdgeAcquired(_Edge):
+    """Company -[:ACQUIRED]-> Company.
+
+    M&A relationship. acquired_at is the close date when known. Not
+    _TemporallyValid because acquisitions are point-in-time events whose
+    effect persists — use acquired_at + the resulting Company structure
+    rather than valid_from/valid_to.
+    """
+    label: Literal["ACQUIRED"] = "ACQUIRED"
+    acquired_at: Optional[date] = None
+    price: Optional[float] = None       # in USD if specified; null if undisclosed
+    confidence: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+
+
+class EdgeProducedBy(_Edge):
+    """Offering -[:PRODUCED_BY]-> Company.
+
+    Functionally redundant with the existing OFFERED_BY (Offering →
+    Company), but accepted because LLM extractors emit this direction
+    naturally ("X is produced by Y") and we lose data when we drop it as
+    Unknown. Writers may choose either; downstream queries should treat
+    OFFERED_BY and PRODUCED_BY as equivalent.
+    """
+    label: Literal["PRODUCED_BY"] = "PRODUCED_BY"
+
+
+class EdgeAlternativeTo(_Edge):
+    """Offering -[:ALTERNATIVE_TO]-> Offering.
+
+    Functional substitute relationship. Foundational for choice-set
+    construction — when buyers evaluate Offering A, they typically
+    compare against its ALTERNATIVE_TO peers. similarity_score in [0,1]
+    captures functional closeness when known.
+    """
+    label: Literal["ALTERNATIVE_TO"] = "ALTERNATIVE_TO"
+    similarity_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+
+
+class EdgeComplementOf(_Edge):
+    """Offering -[:COMPLEMENT_OF]-> Offering.
+
+    Bundle / ecosystem complement — Offering B's value increases when
+    A is also present (e.g. AppleCare complements iPhone). Distinct
+    from ALTERNATIVE_TO which captures substitution.
+    """
+    label: Literal["COMPLEMENT_OF"] = "COMPLEMENT_OF"
+    bundle_strength: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+
+
+class EdgePlays(_Edge, _TemporallyValid):
+    """Person -[:PLAYS]-> StakeholderArchetype.
+
+    v1.4.0 role-binding: an individual plays an archetype role within
+    a specific company context. role_context captures the company or
+    deal scope when the same person plays different roles elsewhere.
+    """
+    label: Literal["PLAYS"] = "PLAYS"
+    role_context: Optional[str] = None    # e.g. "at Acme Inc, 2024-2026"
+
+
+# ---------------------------------------------------------------------------
 # Convenience: registry for writers/importers
 # ---------------------------------------------------------------------------
 
@@ -365,6 +503,7 @@ NODE_MODELS: dict[str, type[BaseModel]] = {
     "Stage": Stage,
     "Transition": Transition,
     "StakeholderArchetype": StakeholderArchetype,
+    "Person": Person,                     # v1.4.0
     "Offering": Offering,
     "Attribute": Attribute,
     "AttributeLevel": AttributeLevel,
@@ -390,6 +529,14 @@ EDGE_MODELS: dict[str, type[BaseModel]] = {
     "OFFERED_BY": EdgeOfferedBy,
     "CONSUMED": EdgeConsumed,
     "PRODUCED": EdgeProduced,
+    # v1.4.0 Continuant-Continuant edges
+    "COMPETES_WITH": EdgeCompetesWith,
+    "PARTNERED_WITH": EdgePartneredWith,
+    "ACQUIRED": EdgeAcquired,
+    "PRODUCED_BY": EdgeProducedBy,
+    "ALTERNATIVE_TO": EdgeAlternativeTo,
+    "COMPLEMENT_OF": EdgeComplementOf,
+    "PLAYS": EdgePlays,
 }
 
 

--- a/poc_v1/ontology/super_ego_projection.json
+++ b/poc_v1/ontology/super_ego_projection.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://subconscious.ai/schemas/super-ego-projection-manifest.json",
-  "schema_version": "1.3.1",
+  "schema_version": "1.4.0",
   "projection_version": "1.0.0",
   "description": "Static integration contract from market-ontology nodes to SuperEgo API surfaces and W&B run/artifact metadata. Credentials are intentionally out of scope.",
   "api": {

--- a/poc_v1/ontology/twenty_app_contract.json
+++ b/poc_v1/ontology/twenty_app_contract.json
@@ -915,7 +915,7 @@
     }
   },
   "projection_version": "1.0.0",
-  "schema_version": "1.3.1",
+  "schema_version": "1.4.0",
   "sync_ledger": {
     "description": "Downstream sync ledgers use these fields to map a tenant-scoped ontology node snapshot to a Twenty record.",
     "stable_key_fields": [

--- a/poc_v1/ontology/twenty_projection.json
+++ b/poc_v1/ontology/twenty_projection.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://subconscious.ai/schemas/twenty-projection-manifest.json",
-  "schema_version": "1.3.1",
+  "schema_version": "1.4.0",
   "projection_version": "1.0.0",
   "metadata_fields": [
     {"name": "ontology_node_id", "type": "text", "required": true},

--- a/scripts/generate_kg_seed_contract.py
+++ b/scripts/generate_kg_seed_contract.py
@@ -25,6 +25,7 @@ GRAPH_TYPES = {
     "Stage": "stage",
     "Transition": "transition",
     "StakeholderArchetype": "stakeholder",
+    "Person": "person",                  # v1.4.0
     "Offering": "offering",
     "Attribute": "attribute",
     "AttributeLevel": "attribute_level",

--- a/scripts/validate_kg_seed.py
+++ b/scripts/validate_kg_seed.py
@@ -52,6 +52,15 @@ FIXTURES = {
     "edges_offering_offered_by.jsonl":     ("OFFERED_BY", True),
     "edges_experiment_run_consumed.jsonl": ("CONSUMED", True),
     "edges_experiment_run_produced.jsonl": ("PRODUCED", True),
+    # v1.4.0 — Continuant-Continuant edges + Person sortal
+    "persons.jsonl":                       ("Person", False),
+    "edges_company_competes_with.jsonl":   ("COMPETES_WITH", True),
+    "edges_company_partnered_with.jsonl":  ("PARTNERED_WITH", True),
+    "edges_company_acquired.jsonl":        ("ACQUIRED", True),
+    "edges_offering_produced_by.jsonl":    ("PRODUCED_BY", True),
+    "edges_offering_alternative_to.jsonl": ("ALTERNATIVE_TO", True),
+    "edges_offering_complement_of.jsonl":  ("COMPLEMENT_OF", True),
+    "edges_person_plays.jsonl":            ("PLAYS", True),
 }
 
 

--- a/tests/test_causal_projection_contracts.py
+++ b/tests/test_causal_projection_contracts.py
@@ -58,12 +58,23 @@ def load_contract(name: str) -> dict:
 
 
 class CausalProjectionContractsTest(unittest.TestCase):
-    def test_schema_adds_only_experiment_run_and_run_edges(self):
+    def test_schema_version_and_additive_types(self):
+        """v1.4.0 adds Person sortal + 7 Continuant-Continuant edges on top
+        of v1.3.1's BASE + ExperimentRun + CONSUMED/PRODUCED. No causal
+        edges have been added (per the no-causal-edges-in-ontology rule)."""
         schema = load_schema()
 
-        self.assertEqual("1.3.1", schema.SCHEMA_VERSION)
-        self.assertEqual(BASE_NODE_TYPES | {"ExperimentRun"}, set(schema.NODE_MODELS))
-        self.assertEqual(BASE_EDGE_TYPES | {"CONSUMED", "PRODUCED"}, set(schema.EDGE_MODELS))
+        self.assertEqual("1.4.0", schema.SCHEMA_VERSION)
+        expected_nodes = BASE_NODE_TYPES | {"ExperimentRun", "Person"}
+        expected_edges = BASE_EDGE_TYPES | {
+            "CONSUMED", "PRODUCED",
+            # v1.4.0 Continuant-Continuant edges
+            "COMPETES_WITH", "PARTNERED_WITH", "ACQUIRED",
+            "PRODUCED_BY", "ALTERNATIVE_TO", "COMPLEMENT_OF",
+            "PLAYS",
+        }
+        self.assertEqual(expected_nodes, set(schema.NODE_MODELS))
+        self.assertEqual(expected_edges, set(schema.EDGE_MODELS))
         self.assertTrue(FORBIDDEN_CAUSAL_EDGE_TYPES.isdisjoint(schema.EDGE_MODELS))
 
     def test_experiment_run_and_new_estimate_types_validate(self):
@@ -250,7 +261,7 @@ class CausalProjectionContractsTest(unittest.TestCase):
             ),
         )
 
-        self.assertEqual("1.3.1", projection["schema_version"])
+        self.assertEqual("1.4.0", projection["schema_version"])
         self.assertCountEqual(
             [
                 "poc_v1/contracts/causal_dag_projection.schema.json",

--- a/tests/test_generate_twenty_app.py
+++ b/tests/test_generate_twenty_app.py
@@ -47,7 +47,7 @@ class GenerateTwentyAppTest(unittest.TestCase):
         estimate = contract["objects"]["estimate"]
         experiment_run = contract["objects"]["experiment_run"]
 
-        self.assertEqual("1.3.1", contract["schema_version"])
+        self.assertEqual("1.4.0", contract["schema_version"])
         self.assertEqual("1.0.0", contract["projection_version"])
         self.assertEqual(
             "poc_v1/ontology/twenty_projection.json",

--- a/tests/test_twenty_projection_manifest.py
+++ b/tests/test_twenty_projection_manifest.py
@@ -24,6 +24,14 @@ def load_manifest():
     return json.loads(MANIFEST_PATH.read_text())
 
 
+# Nodes that the schema declares but Twenty does not yet project.
+# v1.4.0 — Person is opt-in. Twenty consumers that need person-level
+# identity can opt in by adding a `person` projection entry in
+# twenty_projection.json later (trigger per poc_v1/v2_spec.md is "same
+# individual plays role at multiple companies").
+TWENTY_OPT_IN_NODES = {"Person"}
+
+
 class TwentyProjectionManifestTest(unittest.TestCase):
     def test_manifest_covers_schema_and_declares_surfaces(self):
         manifest = load_manifest()
@@ -31,7 +39,8 @@ class TwentyProjectionManifestTest(unittest.TestCase):
         node_types = {obj["ontology_node_type"] for obj in objects.values()}
 
         self.assertEqual(schema.SCHEMA_VERSION, manifest["schema_version"])
-        self.assertEqual(set(schema.NODE_MODELS), node_types)
+        required_node_types = set(schema.NODE_MODELS) - TWENTY_OPT_IN_NODES
+        self.assertEqual(required_node_types, node_types)
 
         primary = {
             obj["object_name"]: obj["ontology_node_type"]


### PR DESCRIPTION
## What
Adds 7 new edges and 1 new node to close the substrate hygiene gap surfaced in [sizzl-trustgraph#181](https://github.com/Subconscious-ai/sizzl-trustgraph/issues/181).

Across 423 LLM extraction chunks, the validator silently dropped ~136 relationships because the natural competitive predicates (`competesWith`, `competitorOf`, `partnersWith`, `alternativeTo`, `acquired`) had no declared home. v1.4.0 gives them one.

**New edges (all Continuant→Continuant, additive, no breakage):**
- `COMPETES_WITH` (Company → Company)
- `PARTNERED_WITH` (Company → Company)
- `ACQUIRED` (Company → Company, with acquired_at + price)
- `PRODUCED_BY` (Offering → Company; inverse of OFFERED_BY)
- `ALTERNATIVE_TO` (Offering → Offering; substitute)
- `COMPLEMENT_OF` (Offering → Offering; bundle / ecosystem)
- `PLAYS` (Person → StakeholderArchetype; role binding)

**New node:** Person (sortal — distinct identity, persistent through time).

Diff: +1,417 / −1,139 across 18 files.

## Why
Substrate hygiene. Today the kg_seed validator drops ~32% of LLM-extracted relationships because the predicates aren't declared. v1.4.0 declares them, lifting recall on the competitive landscape.

## Risk
**Schema bump = cross-repo contract change.** Per workspace CLAUDE.md, this needs paired PRs in spice-harvester (validator consumer) and ai-chatbot (UI consumer) before this can merge. Opening draft so reviewers can see the diff while paired PRs land.

## Test plan
- [ ] `python scripts/validate_kg_seed.py` on existing fixtures — must still pass
- [ ] Paired PR in `spice-harvester` consuming v1.4.0
- [ ] Paired PR in `ai-chatbot` consuming v1.4.0
- [ ] Sample re-extraction of a slug (notion.so or pillsbury) to confirm previously-dropped edges land

Draft. Promote when paired PRs are ready.