### PR TITLE
feat(ontology): add market evidence core

### DIFF
--- a/poc_v1/kg_seed/edges_offering_competes_with.jsonl
+++ b/poc_v1/kg_seed/edges_offering_competes_with.jsonl
@@ -1,0 +1,1 @@
+# v1.4 relation fixture reserved for Offering -[:COMPETES_WITH]-> Offering.

--- a/poc_v1/kg_seed/edges_offering_in_market.jsonl
+++ b/poc_v1/kg_seed/edges_offering_in_market.jsonl
@@ -1,0 +1,1 @@
+# v1.4 relation fixture reserved for Offering -[:OFFERING_IN_MARKET]-> Market.

--- a/poc_v1/kg_seed/edges_offering_targets_stakeholder.jsonl
+++ b/poc_v1/kg_seed/edges_offering_targets_stakeholder.jsonl
@@ -1,0 +1,1 @@
+# v1.4 relation fixture reserved for Offering -[:TARGETS_STAKEHOLDER]-> StakeholderArchetype.

--- a/poc_v1/ontology/edge_schemas.json
+++ b/poc_v1/ontology/edge_schemas.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "v1 POC Edge Schemas",
-  "schema_version": "1.3.1",
+  "schema_version": "1.4.0",
   "type": "object",
   "properties": {
     "FROM": {
@@ -86,6 +86,27 @@
     "OFFERED_BY": {
       "from": "Offering",
       "to": "Company",
+      "properties": {
+        "schema_version": {"type": "string"}
+      }
+    },
+    "COMPETES_WITH": {
+      "from": "Offering",
+      "to": "Offering",
+      "properties": {
+        "schema_version": {"type": "string"}
+      }
+    },
+    "OFFERING_IN_MARKET": {
+      "from": "Offering",
+      "to": "Market",
+      "properties": {
+        "schema_version": {"type": "string"}
+      }
+    },
+    "TARGETS_STAKEHOLDER": {
+      "from": "Offering",
+      "to": "StakeholderArchetype",
       "properties": {
         "schema_version": {"type": "string"}
       }

--- a/poc_v1/ontology/enums.yaml
+++ b/poc_v1/ontology/enums.yaml
@@ -30,6 +30,13 @@ evidence_source_types:
 - executive_interview
 - research_agent
 
+evidence_signal_types:
+- metric
+- observation
+- recommendation
+- objective
+- question
+
 estimate_types:
 - part_worth
 - transition_probability

--- a/poc_v1/ontology/kg_seed_contract.json
+++ b/poc_v1/ontology/kg_seed_contract.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.3.1",
+  "schema_version": "1.4.0",
   "nodes": {
     "Market": {
       "filename": "markets.jsonl",
@@ -154,6 +154,30 @@
       "from": "Offering",
       "to": "Company"
     },
+    "COMPETES_WITH": {
+      "filename": "edges_offering_competes_with.jsonl",
+      "filenames": [
+        "edges_offering_competes_with.jsonl"
+      ],
+      "from": "Offering",
+      "to": "Offering"
+    },
+    "OFFERING_IN_MARKET": {
+      "filename": "edges_offering_in_market.jsonl",
+      "filenames": [
+        "edges_offering_in_market.jsonl"
+      ],
+      "from": "Offering",
+      "to": "Market"
+    },
+    "TARGETS_STAKEHOLDER": {
+      "filename": "edges_offering_targets_stakeholder.jsonl",
+      "filenames": [
+        "edges_offering_targets_stakeholder.jsonl"
+      ],
+      "from": "Offering",
+      "to": "StakeholderArchetype"
+    },
     "CONSUMED": {
       "filename": "edges_experiment_run_consumed.jsonl",
       "filenames": [
@@ -275,6 +299,18 @@
     "edges_offering_offered_by.jsonl": {
       "kind": "edge",
       "label": "OFFERED_BY"
+    },
+    "edges_offering_competes_with.jsonl": {
+      "kind": "edge",
+      "label": "COMPETES_WITH"
+    },
+    "edges_offering_in_market.jsonl": {
+      "kind": "edge",
+      "label": "OFFERING_IN_MARKET"
+    },
+    "edges_offering_targets_stakeholder.jsonl": {
+      "kind": "edge",
+      "label": "TARGETS_STAKEHOLDER"
     },
     "edges_experiment_run_consumed.jsonl": {
       "kind": "edge",

--- a/poc_v1/ontology/node_schemas.json
+++ b/poc_v1/ontology/node_schemas.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "v1 POC Node Schemas",
-  "schema_version": "1.3.1",
+  "schema_version": "1.4.0",
   "type": "object",
   "properties": {
     "Market": {
@@ -169,6 +169,10 @@
         "retrieval_query": {"type": ["string", "null"]},
         "extractor_version": {"type": ["string", "null"]},
         "confidence": {"type": ["number", "null"], "minimum": 0.0, "maximum": 1.0},
+        "signal_type": {
+          "type": ["string", "null"],
+          "enum": ["metric", "observation", "recommendation", "objective", "question", null]
+        },
         "period_observed": {"type": ["string", "null"]},
         "schema_version": {"type": "string"},
         "ingested_at": {"type": ["string", "null"], "format": "date-time"}

--- a/poc_v1/ontology/ontology_spec.md
+++ b/poc_v1/ontology/ontology_spec.md
@@ -59,6 +59,9 @@ Execution record tying an ontology snapshot to SuperEgo/W&B run and artifact met
 | ABOUT | Transition OR Estimate | * | Polymorphic |
 | HAS_ATTRIBUTE | Offering | Attribute | |
 | OFFERED_BY | Offering | Company | Canonical offering-to-company rollup link |
+| COMPETES_WITH | Offering | Offering | Direct competitive-alternative claim, only when explicit in source text |
+| OFFERING_IN_MARKET | Offering | Market | Offering-scoped market membership; distinct from Transition-scoped `IN_MARKET` |
+| TARGETS_STAKEHOLDER | Offering | StakeholderArchetype | Explicit buyer, user, decision-maker, or stakeholder target |
 | HAS_LEVEL | Attribute OR Trait | AttributeLevel OR TraitLevel | |
 | HAS_TRAIT | StakeholderArchetype | Trait | |
 | RELEVANT_AT | Attribute | Stage | `{score, valid_from, valid_to, evidence_ids}` — temporal relevance |
@@ -84,6 +87,7 @@ Execution record tying an ontology snapshot to SuperEgo/W&B run and artifact met
 3. Splink entity resolution runs after each ingestion batch on Offerings and StakeholderArchetypes.
 4. Every write includes `schema_version`.
 5. Estimates always include `ontology_snapshot_hash` computed from the subgraph Subconscious consumed.
+6. Competitive-market extraction must prefer explicit Offering edges (`COMPETES_WITH`, `OFFERING_IN_MARKET`, `TARGETS_STAKEHOLDER`) plus Evidence with `extracted_claim`, `source_ref` or `source_url`, and `signal_type`. Do not invent a relation when source text does not explicitly support it.
 
 ## Temporal conventions
 

--- a/poc_v1/ontology/ontology_spec.md
+++ b/poc_v1/ontology/ontology_spec.md
@@ -41,6 +41,10 @@ Plausible levels for a Trait in a Market for a time window. Temporally valid.
 
 ### Evidence
 Grounding for any node or edge. Required for every extracted fact per the ingestion rules.
+TrustGraph projection note: Evidence datatype fields (`source_ref`,
+`source_url`, `extracted_claim`, `signal_type`, `period_observed`) must carry
+`rdfs:domain = Evidence`. TrustGraph's ontology selector uses datatype-property
+domains to include source/claim fields when the Evidence class is selected.
 
 ### Estimate
 Results returned from Subconscious. Every Estimate carries `ontology_snapshot_hash` so results are always interpretable against the ontology state they were computed on.

--- a/poc_v1/ontology/schema.py
+++ b/poc_v1/ontology/schema.py
@@ -7,7 +7,7 @@ This is the single source of truth for the schema. Keep it aligned with:
   - ontology/edge_schemas.json
   - graph-store adapter constraints/import scripts
 
-Schema version: 1.3.1
+Schema version: 1.4.0
 """
 
 from __future__ import annotations
@@ -18,7 +18,7 @@ from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
-SCHEMA_VERSION = "1.3.1"
+SCHEMA_VERSION = "1.4.0"
 
 
 # ---------------------------------------------------------------------------
@@ -50,6 +50,14 @@ class EvidenceSourceType(str, Enum):
     DECK = "deck"
     EXECUTIVE_INTERVIEW = "executive_interview"
     RESEARCH_AGENT = "research_agent"
+
+
+class EvidenceSignalType(str, Enum):
+    METRIC = "metric"
+    OBSERVATION = "observation"
+    RECOMMENDATION = "recommendation"
+    OBJECTIVE = "objective"
+    QUESTION = "question"
 
 
 class AttributeDataType(str, Enum):
@@ -213,6 +221,7 @@ class Evidence(_VersionedNode):
     retrieval_query: Optional[str] = None
     extractor_version: Optional[str] = None
     confidence: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    signal_type: Optional[EvidenceSignalType] = None
     period_observed: Optional[str] = None
 
 
@@ -345,6 +354,25 @@ class EdgeOfferedBy(_Edge):
     label: Literal["OFFERED_BY"] = "OFFERED_BY"
 
 
+class EdgeCompetesWith(_Edge):
+    """Offering -[:COMPETES_WITH]-> Offering."""
+    label: Literal["COMPETES_WITH"] = "COMPETES_WITH"
+
+
+class EdgeOfferingInMarket(_Edge):
+    """Offering -[:OFFERING_IN_MARKET]-> Market.
+
+    Kept distinct from Transition -[:IN_MARKET]-> Market because the
+    TrustGraph projection has one domain/range pair per property.
+    """
+    label: Literal["OFFERING_IN_MARKET"] = "OFFERING_IN_MARKET"
+
+
+class EdgeTargetsStakeholder(_Edge):
+    """Offering -[:TARGETS_STAKEHOLDER]-> StakeholderArchetype."""
+    label: Literal["TARGETS_STAKEHOLDER"] = "TARGETS_STAKEHOLDER"
+
+
 class EdgeConsumed(_Edge):
     """ExperimentRun -[:CONSUMED]-> any ontology context node."""
     label: Literal["CONSUMED"] = "CONSUMED"
@@ -388,6 +416,9 @@ EDGE_MODELS: dict[str, type[BaseModel]] = {
     "RELEVANT_AT": EdgeRelevantAt,
     "SUPPORTS": EdgeSupports,
     "OFFERED_BY": EdgeOfferedBy,
+    "COMPETES_WITH": EdgeCompetesWith,
+    "OFFERING_IN_MARKET": EdgeOfferingInMarket,
+    "TARGETS_STAKEHOLDER": EdgeTargetsStakeholder,
     "CONSUMED": EdgeConsumed,
     "PRODUCED": EdgeProduced,
 }

--- a/poc_v1/ontology/super_ego_projection.json
+++ b/poc_v1/ontology/super_ego_projection.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://subconscious.ai/schemas/super-ego-projection-manifest.json",
-  "schema_version": "1.3.1",
+  "schema_version": "1.4.0",
   "projection_version": "1.0.0",
   "description": "Static integration contract from market-ontology nodes to SuperEgo API surfaces and W&B run/artifact metadata. Credentials are intentionally out of scope.",
   "api": {

--- a/poc_v1/ontology/trustgraph_ontology.json
+++ b/poc_v1/ontology/trustgraph_ontology.json
@@ -4,8 +4,8 @@
     "name": "Sizzl Market Ontology",
     "namespace": "https://causl.io/ontology/sizzl/v1#",
     "description": "TrustGraph Ontology RAG projection of the canonical Sizzl market ontology.",
-    "schemaVersion": "1.3.1",
-    "projectionVersion": "1.0.0"
+    "schemaVersion": "1.4.0",
+    "projectionVersion": "1.1.0"
   },
   "classes": {
     "SizzlEntity": {
@@ -328,6 +328,45 @@
       "rdfs:domain": "Offering",
       "rdfs:range": "Company"
     },
+    "competesWith": {
+      "uri": "https://causl.io/ontology/sizzl/v1#competesWith",
+      "type": "owl:ObjectProperty",
+      "rdfs:label": [
+        {
+          "value": "competes with",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Connects one offering to another offering when source text explicitly states they compete or are alternatives in the same buying decision.",
+      "rdfs:domain": "Offering",
+      "rdfs:range": "Offering"
+    },
+    "offeringInMarket": {
+      "uri": "https://causl.io/ontology/sizzl/v1#offeringInMarket",
+      "type": "owl:ObjectProperty",
+      "rdfs:label": [
+        {
+          "value": "offering in market",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Connects an offering to the bounded market it participates in. This is the Offering-scoped market relation; Transition keeps the legacy inMarket relation.",
+      "rdfs:domain": "Offering",
+      "rdfs:range": "Market"
+    },
+    "targetsStakeholder": {
+      "uri": "https://causl.io/ontology/sizzl/v1#targetsStakeholder",
+      "type": "owl:ObjectProperty",
+      "rdfs:label": [
+        {
+          "value": "targets stakeholder",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Connects an offering to a buyer, user, decision-maker, or stakeholder archetype it is explicitly aimed at.",
+      "rdfs:domain": "Offering",
+      "rdfs:range": "StakeholderArchetype"
+    },
     "consumed": {
       "uri": "https://causl.io/ontology/sizzl/v1#consumed",
       "type": "owl:ObjectProperty",
@@ -438,6 +477,18 @@
       "rdfs:comment": "Extraction property for canonical field confidence.",
       "rdfs:range": "xsd:double"
     },
+    "sourceType": {
+      "uri": "https://causl.io/ontology/sizzl/v1#sourceType",
+      "type": "owl:DatatypeProperty",
+      "rdfs:label": [
+        {
+          "value": "source type",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Extraction property for canonical field source_type.",
+      "rdfs:range": "xsd:string"
+    },
     "sourceRef": {
       "uri": "https://causl.io/ontology/sizzl/v1#sourceRef",
       "type": "owl:DatatypeProperty",
@@ -472,6 +523,30 @@
         }
       ],
       "rdfs:comment": "Extraction property for canonical field extracted_claim.",
+      "rdfs:range": "xsd:string"
+    },
+    "signalType": {
+      "uri": "https://causl.io/ontology/sizzl/v1#signalType",
+      "type": "owl:DatatypeProperty",
+      "rdfs:label": [
+        {
+          "value": "signal type",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Extraction property for canonical field signal_type.",
+      "rdfs:range": "xsd:string"
+    },
+    "periodObserved": {
+      "uri": "https://causl.io/ontology/sizzl/v1#periodObserved",
+      "type": "owl:DatatypeProperty",
+      "rdfs:label": [
+        {
+          "value": "period observed",
+          "lang": "en"
+        }
+      ],
+      "rdfs:comment": "Extraction property for canonical field period_observed.",
       "rdfs:range": "xsd:string"
     }
   }

--- a/poc_v1/ontology/trustgraph_ontology.json
+++ b/poc_v1/ontology/trustgraph_ontology.json
@@ -486,8 +486,9 @@
           "lang": "en"
         }
       ],
-      "rdfs:comment": "Extraction property for canonical field source_type.",
-      "rdfs:range": "xsd:string"
+      "rdfs:comment": "Evidence source type, such as web, analyst_report, benchmark, executive_interview, experiment, or other source category named by the source text or ingestion metadata.",
+      "rdfs:range": "xsd:string",
+      "rdfs:domain": "Evidence"
     },
     "sourceRef": {
       "uri": "https://causl.io/ontology/sizzl/v1#sourceRef",
@@ -498,8 +499,9 @@
           "lang": "en"
         }
       ],
-      "rdfs:comment": "Extraction property for canonical field source_ref.",
-      "rdfs:range": "xsd:string"
+      "rdfs:comment": "Evidence source reference. Use a stable document title, report name, source ID, or publisher reference from the text or ingestion metadata.",
+      "rdfs:range": "xsd:string",
+      "rdfs:domain": "Evidence"
     },
     "sourceUrl": {
       "uri": "https://causl.io/ontology/sizzl/v1#sourceUrl",
@@ -510,8 +512,9 @@
           "lang": "en"
         }
       ],
-      "rdfs:comment": "Extraction property for canonical field source_url.",
-      "rdfs:range": "xsd:anyURI"
+      "rdfs:comment": "Evidence source URL. Use only a URL explicitly present in the source text or ingestion metadata; never invent one.",
+      "rdfs:range": "xsd:anyURI",
+      "rdfs:domain": "Evidence"
     },
     "extractedClaim": {
       "uri": "https://causl.io/ontology/sizzl/v1#extractedClaim",
@@ -522,8 +525,9 @@
           "lang": "en"
         }
       ],
-      "rdfs:comment": "Extraction property for canonical field extracted_claim.",
-      "rdfs:range": "xsd:string"
+      "rdfs:comment": "Evidence claim as a verbatim or tightly paraphrased claim from the source text. It must be falsifiable and support the linked ontology entity or relationship.",
+      "rdfs:range": "xsd:string",
+      "rdfs:domain": "Evidence"
     },
     "signalType": {
       "uri": "https://causl.io/ontology/sizzl/v1#signalType",
@@ -534,8 +538,9 @@
           "lang": "en"
         }
       ],
-      "rdfs:comment": "Extraction property for canonical field signal_type.",
-      "rdfs:range": "xsd:string"
+      "rdfs:comment": "Evidence signal type. Use one of: metric, observation, recommendation, objective, or question.",
+      "rdfs:range": "xsd:string",
+      "rdfs:domain": "Evidence"
     },
     "periodObserved": {
       "uri": "https://causl.io/ontology/sizzl/v1#periodObserved",
@@ -546,8 +551,9 @@
           "lang": "en"
         }
       ],
-      "rdfs:comment": "Extraction property for canonical field period_observed.",
-      "rdfs:range": "xsd:string"
+      "rdfs:comment": "Evidence observation period when the source states one, such as 2026-Q2, May 2026, or a report period.",
+      "rdfs:range": "xsd:string",
+      "rdfs:domain": "Evidence"
     }
   }
 }

--- a/poc_v1/ontology/trustgraph_projection.json
+++ b/poc_v1/ontology/trustgraph_projection.json
@@ -178,11 +178,47 @@
     "validFrom": {"field": "valid_from", "label": "valid from", "range": "xsd:date"},
     "validTo": {"field": "valid_to", "label": "valid to", "range": "xsd:date"},
     "confidence": {"field": "confidence", "label": "confidence", "range": "xsd:double"},
-    "sourceType": {"field": "source_type", "label": "source type", "range": "xsd:string"},
-    "sourceRef": {"field": "source_ref", "label": "source reference", "range": "xsd:string"},
-    "sourceUrl": {"field": "source_url", "label": "source URL", "range": "xsd:anyURI"},
-    "extractedClaim": {"field": "extracted_claim", "label": "extracted claim", "range": "xsd:string"},
-    "signalType": {"field": "signal_type", "label": "signal type", "range": "xsd:string"},
-    "periodObserved": {"field": "period_observed", "label": "period observed", "range": "xsd:string"}
+    "sourceType": {
+      "field": "source_type",
+      "label": "source type",
+      "range": "xsd:string",
+      "domain": "Evidence",
+      "comment": "Evidence source type, such as web, analyst_report, benchmark, executive_interview, experiment, or other source category named by the source text or ingestion metadata."
+    },
+    "sourceRef": {
+      "field": "source_ref",
+      "label": "source reference",
+      "range": "xsd:string",
+      "domain": "Evidence",
+      "comment": "Evidence source reference. Use a stable document title, report name, source ID, or publisher reference from the text or ingestion metadata."
+    },
+    "sourceUrl": {
+      "field": "source_url",
+      "label": "source URL",
+      "range": "xsd:anyURI",
+      "domain": "Evidence",
+      "comment": "Evidence source URL. Use only a URL explicitly present in the source text or ingestion metadata; never invent one."
+    },
+    "extractedClaim": {
+      "field": "extracted_claim",
+      "label": "extracted claim",
+      "range": "xsd:string",
+      "domain": "Evidence",
+      "comment": "Evidence claim as a verbatim or tightly paraphrased claim from the source text. It must be falsifiable and support the linked ontology entity or relationship."
+    },
+    "signalType": {
+      "field": "signal_type",
+      "label": "signal type",
+      "range": "xsd:string",
+      "domain": "Evidence",
+      "comment": "Evidence signal type. Use one of: metric, observation, recommendation, objective, or question."
+    },
+    "periodObserved": {
+      "field": "period_observed",
+      "label": "period observed",
+      "range": "xsd:string",
+      "domain": "Evidence",
+      "comment": "Evidence observation period when the source states one, such as 2026-Q2, May 2026, or a report period."
+    }
   }
 }

--- a/poc_v1/ontology/trustgraph_projection.json
+++ b/poc_v1/ontology/trustgraph_projection.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://causl.io/schemas/trustgraph-ontology-projection.json",
-  "projectionVersion": "1.0.0",
+  "projectionVersion": "1.1.0",
   "ontologyId": "sizzl-market-v1",
   "name": "Sizzl Market Ontology",
   "namespace": "https://causl.io/ontology/sizzl/v1#",
@@ -136,6 +136,27 @@
       "domain": "Offering",
       "range": "Company"
     },
+    "competesWith": {
+      "edgeLabel": "COMPETES_WITH",
+      "label": "competes with",
+      "comment": "Connects one offering to another offering when source text explicitly states they compete or are alternatives in the same buying decision.",
+      "domain": "Offering",
+      "range": "Offering"
+    },
+    "offeringInMarket": {
+      "edgeLabel": "OFFERING_IN_MARKET",
+      "label": "offering in market",
+      "comment": "Connects an offering to the bounded market it participates in. This is the Offering-scoped market relation; Transition keeps the legacy inMarket relation.",
+      "domain": "Offering",
+      "range": "Market"
+    },
+    "targetsStakeholder": {
+      "edgeLabel": "TARGETS_STAKEHOLDER",
+      "label": "targets stakeholder",
+      "comment": "Connects an offering to a buyer, user, decision-maker, or stakeholder archetype it is explicitly aimed at.",
+      "domain": "Offering",
+      "range": "StakeholderArchetype"
+    },
     "consumed": {
       "edgeLabel": "CONSUMED",
       "label": "consumed",
@@ -157,8 +178,11 @@
     "validFrom": {"field": "valid_from", "label": "valid from", "range": "xsd:date"},
     "validTo": {"field": "valid_to", "label": "valid to", "range": "xsd:date"},
     "confidence": {"field": "confidence", "label": "confidence", "range": "xsd:double"},
+    "sourceType": {"field": "source_type", "label": "source type", "range": "xsd:string"},
     "sourceRef": {"field": "source_ref", "label": "source reference", "range": "xsd:string"},
     "sourceUrl": {"field": "source_url", "label": "source URL", "range": "xsd:anyURI"},
-    "extractedClaim": {"field": "extracted_claim", "label": "extracted claim", "range": "xsd:string"}
+    "extractedClaim": {"field": "extracted_claim", "label": "extracted claim", "range": "xsd:string"},
+    "signalType": {"field": "signal_type", "label": "signal type", "range": "xsd:string"},
+    "periodObserved": {"field": "period_observed", "label": "period observed", "range": "xsd:string"}
   }
 }

--- a/poc_v1/ontology/twenty_app_contract.json
+++ b/poc_v1/ontology/twenty_app_contract.json
@@ -915,7 +915,7 @@
     }
   },
   "projection_version": "1.0.0",
-  "schema_version": "1.3.1",
+  "schema_version": "1.4.0",
   "sync_ledger": {
     "description": "Downstream sync ledgers use these fields to map a tenant-scoped ontology node snapshot to a Twenty record.",
     "stable_key_fields": [

--- a/poc_v1/ontology/twenty_projection.json
+++ b/poc_v1/ontology/twenty_projection.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://subconscious.ai/schemas/twenty-projection-manifest.json",
-  "schema_version": "1.3.1",
+  "schema_version": "1.4.0",
   "projection_version": "1.0.0",
   "metadata_fields": [
     {"name": "ontology_node_id", "type": "text", "required": true},

--- a/scripts/generate_trustgraph_ontology.py
+++ b/scripts/generate_trustgraph_ontology.py
@@ -75,6 +75,25 @@ def _object_property(namespace: str, prop_id: str, spec: dict[str, Any], class_i
     return out
 
 
+def _datatype_property(namespace: str, prop_id: str, spec: dict[str, Any], class_ids: set[str]) -> dict[str, Any]:
+    out = {
+        "uri": f"{namespace}{prop_id}",
+        "type": "owl:DatatypeProperty",
+        "rdfs:label": _label(spec["label"]),
+        "rdfs:comment": spec.get(
+            "comment",
+            f"Extraction property for canonical field {spec['field']}.",
+        ),
+        "rdfs:range": spec["range"],
+    }
+    domain = spec.get("domain")
+    if domain:
+        if domain not in class_ids:
+            raise SystemExit(f"{prop_id}: unknown domain {domain}")
+        out["rdfs:domain"] = domain
+    return out
+
+
 def build_ontology() -> dict[str, Any]:
     projection = load_projection()
     _assert_edge_coverage(projection)
@@ -107,13 +126,7 @@ def build_ontology() -> dict[str, Any]:
         for prop_id, spec in projection["objectProperties"].items()
     }
     datatype_properties = {
-        prop_id: {
-            "uri": f"{namespace}{prop_id}",
-            "type": "owl:DatatypeProperty",
-            "rdfs:label": _label(spec["label"]),
-            "rdfs:comment": f"Extraction property for canonical field {spec['field']}.",
-            "rdfs:range": spec["range"],
-        }
+        prop_id: _datatype_property(namespace, prop_id, spec, set(classes))
         for prop_id, spec in projection["datatypeProperties"].items()
     }
     return {

--- a/scripts/validate_kg_seed.py
+++ b/scripts/validate_kg_seed.py
@@ -50,6 +50,9 @@ FIXTURES = {
     "edges_evidence_supports.jsonl":       ("SUPPORTS", True),
     "companies.jsonl":                     ("Company", False),
     "edges_offering_offered_by.jsonl":     ("OFFERED_BY", True),
+    "edges_offering_competes_with.jsonl":  ("COMPETES_WITH", True),
+    "edges_offering_in_market.jsonl":      ("OFFERING_IN_MARKET", True),
+    "edges_offering_targets_stakeholder.jsonl": ("TARGETS_STAKEHOLDER", True),
     "edges_experiment_run_consumed.jsonl": ("CONSUMED", True),
     "edges_experiment_run_produced.jsonl": ("PRODUCED", True),
 }

--- a/tests/test_causal_projection_contracts.py
+++ b/tests/test_causal_projection_contracts.py
@@ -37,6 +37,9 @@ BASE_EDGE_TYPES = {
     "RELEVANT_AT",
     "SUPPORTS",
     "OFFERED_BY",
+    "COMPETES_WITH",
+    "OFFERING_IN_MARKET",
+    "TARGETS_STAKEHOLDER",
 }
 
 FORBIDDEN_CAUSAL_EDGE_TYPES = {
@@ -61,7 +64,7 @@ class CausalProjectionContractsTest(unittest.TestCase):
     def test_schema_adds_only_experiment_run_and_run_edges(self):
         schema = load_schema()
 
-        self.assertEqual("1.3.1", schema.SCHEMA_VERSION)
+        self.assertEqual("1.4.0", schema.SCHEMA_VERSION)
         self.assertEqual(BASE_NODE_TYPES | {"ExperimentRun"}, set(schema.NODE_MODELS))
         self.assertEqual(BASE_EDGE_TYPES | {"CONSUMED", "PRODUCED"}, set(schema.EDGE_MODELS))
         self.assertTrue(FORBIDDEN_CAUSAL_EDGE_TYPES.isdisjoint(schema.EDGE_MODELS))
@@ -250,7 +253,7 @@ class CausalProjectionContractsTest(unittest.TestCase):
             ),
         )
 
-        self.assertEqual("1.3.1", projection["schema_version"])
+        self.assertEqual("1.4.0", projection["schema_version"])
         self.assertCountEqual(
             [
                 "poc_v1/contracts/causal_dag_projection.schema.json",

--- a/tests/test_generate_twenty_app.py
+++ b/tests/test_generate_twenty_app.py
@@ -47,7 +47,7 @@ class GenerateTwentyAppTest(unittest.TestCase):
         estimate = contract["objects"]["estimate"]
         experiment_run = contract["objects"]["experiment_run"]
 
-        self.assertEqual("1.3.1", contract["schema_version"])
+        self.assertEqual("1.4.0", contract["schema_version"])
         self.assertEqual("1.0.0", contract["projection_version"])
         self.assertEqual(
             "poc_v1/ontology/twenty_projection.json",

--- a/tests/test_graphiti_views.py
+++ b/tests/test_graphiti_views.py
@@ -70,7 +70,8 @@ class TestEdgeTypesAreCanonicalOntology(unittest.TestCase):
         expected = {
             "FROM", "TO", "IN_MARKET", "RELEVANT_TO", "ABOUT",
             "HAS_ATTRIBUTE", "HAS_LEVEL", "HAS_TRAIT", "RELEVANT_AT",
-            "SUPPORTS", "OFFERED_BY",
+            "SUPPORTS", "OFFERED_BY", "COMPETES_WITH",
+            "OFFERING_IN_MARKET", "TARGETS_STAKEHOLDER",
         }
         self.assertEqual(set(EDGE_TYPES) & expected, expected)
 
@@ -116,6 +117,17 @@ class TestEdgeTypeMap(unittest.TestCase):
         from poc_v1.ontology.graphiti_views import EDGE_TYPE_MAP
 
         self.assertIn("OFFERED_BY", EDGE_TYPE_MAP[("Offering", "Company")])
+
+    def test_market_evidence_core_edges_route_correctly(self):
+        """Market evidence core edges stay typed at the graph boundary."""
+        from poc_v1.ontology.graphiti_views import EDGE_TYPE_MAP
+
+        self.assertIn("COMPETES_WITH", EDGE_TYPE_MAP[("Offering", "Offering")])
+        self.assertIn("OFFERING_IN_MARKET", EDGE_TYPE_MAP[("Offering", "Market")])
+        self.assertIn(
+            "TARGETS_STAKEHOLDER",
+            EDGE_TYPE_MAP[("Offering", "StakeholderArchetype")],
+        )
 
     def test_polymorphic_from_expands(self):
         """ABOUT has from=[Transition, Estimate], to=*."""

--- a/tests/test_trustgraph_ontology.py
+++ b/tests/test_trustgraph_ontology.py
@@ -83,6 +83,26 @@ class TrustGraphOntologyProjectionTest(unittest.TestCase):
             set(ontology["datatypeProperties"]),
         )
 
+    def test_evidence_datatype_properties_have_domain_and_extraction_guidance(self):
+        ontology = load_generator().build_ontology()
+
+        for prop_id in {
+            "sourceType",
+            "sourceRef",
+            "sourceUrl",
+            "extractedClaim",
+            "signalType",
+            "periodObserved",
+        }:
+            prop = ontology["datatypeProperties"][prop_id]
+            self.assertEqual("Evidence", prop["rdfs:domain"])
+            self.assertIn("Evidence", prop["rdfs:comment"])
+
+        self.assertIn(
+            "verbatim or tightly paraphrased claim",
+            ontology["datatypeProperties"]["extractedClaim"]["rdfs:comment"],
+        )
+
     def test_market_evidence_core_relations_are_projected(self):
         ontology = load_generator().build_ontology()
 

--- a/tests/test_trustgraph_ontology.py
+++ b/tests/test_trustgraph_ontology.py
@@ -29,7 +29,7 @@ class TrustGraphOntologyProjectionTest(unittest.TestCase):
     def test_generated_classes_match_canonical_nodes_plus_root(self):
         ontology = load_generator().build_ontology()
 
-        self.assertEqual("1.3.1", ontology["metadata"]["schemaVersion"])
+        self.assertEqual("1.4.0", ontology["metadata"]["schemaVersion"])
         self.assertIn("SizzlEntity", ontology["classes"])
         self.assertEqual(
             set(schema.NODE_MODELS) | {"SizzlEntity"},
@@ -73,12 +73,74 @@ class TrustGraphOntologyProjectionTest(unittest.TestCase):
                 "validFrom",
                 "validTo",
                 "confidence",
+                "sourceType",
                 "sourceRef",
                 "sourceUrl",
                 "extractedClaim",
+                "signalType",
+                "periodObserved",
             },
             set(ontology["datatypeProperties"]),
         )
+
+    def test_market_evidence_core_relations_are_projected(self):
+        ontology = load_generator().build_ontology()
+
+        self.assertEqual(
+            {
+                "rdfs:domain": "Offering",
+                "rdfs:range": "Offering",
+            },
+            {
+                "rdfs:domain": ontology["objectProperties"]["competesWith"]["rdfs:domain"],
+                "rdfs:range": ontology["objectProperties"]["competesWith"]["rdfs:range"],
+            },
+        )
+        self.assertEqual(
+            {
+                "rdfs:domain": "Offering",
+                "rdfs:range": "Market",
+            },
+            {
+                "rdfs:domain": ontology["objectProperties"]["offeringInMarket"]["rdfs:domain"],
+                "rdfs:range": ontology["objectProperties"]["offeringInMarket"]["rdfs:range"],
+            },
+        )
+        self.assertEqual(
+            {
+                "rdfs:domain": "Offering",
+                "rdfs:range": "StakeholderArchetype",
+            },
+            {
+                "rdfs:domain": ontology["objectProperties"]["targetsStakeholder"]["rdfs:domain"],
+                "rdfs:range": ontology["objectProperties"]["targetsStakeholder"]["rdfs:range"],
+            },
+        )
+
+    def test_evidence_signal_type_is_validated(self):
+        evidence = schema.validate_node(
+            "Evidence",
+            {
+                "id": "evidence_notion_competitor_claim",
+                "source_type": "web",
+                "source_ref": "notion://competitor-research",
+                "extracted_claim": "Notion competes with Coda for workspace buyers.",
+                "signal_type": "observation",
+            },
+        )
+
+        self.assertEqual(schema.EvidenceSignalType.OBSERVATION, evidence.signal_type)
+
+        with self.assertRaises(ValueError):
+            schema.validate_node(
+                "Evidence",
+                {
+                    "id": "evidence_bad_signal",
+                    "source_type": "web",
+                    "source_ref": "notion://competitor-research",
+                    "signal_type": "vibes",
+                },
+            )
 
     def test_checked_in_artifact_matches_generator(self):
         generator = load_generator()


### PR DESCRIPTION
## Summary

Refs Subconscious-ai/sizzl-trustgraph#263.

Adds the narrow v1.4 market evidence core needed for TrustGraph-native competitive-market extraction:

- Evidence `signal_type` enum + TrustGraph projection properties `sourceType`, `signalType`, `periodObserved`.
- Evidence TrustGraph datatype properties now carry `domain: Evidence` plus extraction guidance, so TrustGraph auto-includes source/claim fields when Evidence is selected.
- Offering relations: `COMPETES_WITH`, `OFFERING_IN_MARKET`, `TARGETS_STAKEHOLDER`.
- Generated TrustGraph ontology, kg_seed contract, and Twenty contract updates.
- Tests for projection coverage, Evidence signal validation, Evidence datatype domains, and Graphiti edge routing.
- Ontology spec note documenting why the Evidence domains matter for TrustGraph selection.

This is intentionally smaller than draft PR #62. It does not introduce broad continuant-continuant ontology scope; it only adds the minimal cross-industry relations needed for Sizzl's trust floor.

## Validation

- `PYTHONPATH=. pytest tests/test_trustgraph_ontology.py -q` -> 9 passed, 1 skipped.
- `bash scripts/agent/validate-fast.sh` -> 124 tests passed, 1 skipped.

## Runtime Evidence From Sizzl

Sizzl PR Subconscious-ai/sizzl-trustgraph#264 loaded this branch's generated artifact into live TrustGraph and clean re-ingested `corp-notion-so`.

- Baseline polluted graph: Evidence extractedClaim coverage 0%.
- Best clean run after adding Evidence datatype domains: Evidence source coverage 100%, extractedClaim coverage 100%.
- The graph is still not trusted overall because TrustGraph's simplified converter does not enforce relationship domain/range and does not attach direct provenance to typed Sizzl nodes.

## Follow-ups

- Sizzl mirror/audit PR references this branch until the generated artifact lands on `main`.
- Upstream TrustGraph issue: trustgraph-ai/trustgraph#920.