### PR TITLE
docs(claude): note CI gating workflows and Python 3.11 baseline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,11 @@ python -m py_compile poc_v1/ontology/schema.py
 
 If any fail, fix before opening a PR. Do not use `--no-verify`.
 
+`main` is gated by two GitHub Actions workflows: `ci.yml` runs the full
+sequence above; `symphony-gate.yml` runs the `scripts/agent/` harness
+(`readiness.sh`, `preflight.sh`, `validate-fast.sh`). Python 3.11 is the
+CI baseline (`requires-python >= 3.11`) — do not rely on 3.12+-only syntax.
+
 ## Symphony Contract
 
 - Task types: `schema-contract`, `ontology-fixture`, `docs-canary`, `ci-harness`, `consumer-contract`.


### PR DESCRIPTION
## What
- Add a short note to `CLAUDE.md` documenting that `main` is gated by two GitHub Actions workflows (`ci.yml`, `symphony-gate.yml`) and that Python 3.11 is the CI baseline.

## Why
Originated from a `/init` pass. PR #66 already merged the `causal_dag_v1/` architecture and directory-layout additions that pass had drafted — this is the one residual fact not yet in `CLAUDE.md`. The 3.11 baseline is load-bearing: 3.12-only syntax fails CI opaquely otherwise.

No issue filed — 5-line docs-only change, within the "tiny fix → direct PR" carve-out.

## Risk
None. Docs-only; `scripts/check-doc-rot.sh` passes locally.

## Test plan
- [x] `bash scripts/check-doc-rot.sh` → `[doc-rot] OK`