### PR TITLE
Feat #72: canonical ontology IRIs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,11 @@ from poc_v1.ontology.identity import (
     domain_to_slug,
     normalize_slug,  # boundary validator (HTTP routes; subset of to_identity)
 )
+from poc_v1.ontology.iri import (
+    to_iri,        # entity class + node id -> canonical RDF IRI
+    parse_iri,     # canonical RDF IRI -> entity class + node id
+    predicate_iri, # edge label -> canonical RDF predicate IRI
+)
 ```
 
 `graphiti_views` derives ENTITY_TYPES/EDGE_TYPES from NODE_MODELS/EDGE_MODELS
@@ -116,6 +121,10 @@ code change needed.
 distinct group_ids (`spice_ibm_com` vs `spice_ibm_ai`); subdomains
 collapse to the brand (`mail.acme.io` → `acme_io`). IDN punycodes,
 multi-part TLDs (`lloyds.co.uk` → `lloyds_co_uk`) work out of the box.
+
+`iri` is the canonical RDF/TrustGraph identifier surface. Entity IRIs use
+`https://ontology.subconscious.ai/<Class>/<id>`; predicate IRIs use
+`https://ontology.subconscious.ai/predicate/<EDGE_LABEL>`.
 
 ## W&B/SuperEgo Loop
 

--- a/README.md
+++ b/README.md
@@ -107,12 +107,19 @@ from poc_v1.ontology.identity import (
     to_identity,     # email/URL/domain/slug → identity (PSL-aware)
     normalize_slug,  # boundary validator for HTTP routes (no PSL)
 )
+from poc_v1.ontology.iri import (
+    to_iri,        # (class_name, node_id) -> stable entity IRI
+    parse_iri,     # entity IRI -> (class_name, node_id)
+    predicate_iri, # edge label -> stable predicate IRI
+)
 ```
 
 Single source of truth — adding a new node/edge to `schema.py`
 automatically propagates to `graphiti_views`. Identity shape (the trio
 `canonical_domain` / `route_slug` / `group_id`) is part of "what
 defines a Company" so it lives next to the Pydantic Company model.
+IRI shape is also centralized here so RDF/TrustGraph projections use one
+dereferenceable namespace: `https://ontology.subconscious.ai`.
 
 ## Pipeline
 

--- a/poc_v1/ontology/iri.py
+++ b/poc_v1/ontology/iri.py
@@ -1,0 +1,64 @@
+"""Canonical IRIs for ontology entities and predicates.
+
+RDF/TrustGraph projections need stable, reversible identifiers. The Pydantic
+models keep compact node IDs; this module owns the public URL-safe IRI form
+consumers should use when serializing those records as triples.
+"""
+from __future__ import annotations
+
+from urllib.parse import quote, unquote, urlparse
+
+from .schema import EDGE_MODELS, NODE_MODELS
+
+BASE_NAMESPACE = "https://ontology.subconscious.ai"
+PREDICATE_PATH = "predicate"
+
+
+def _encode_segment(value: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError("IRI segment must be a non-empty string")
+    return quote(value, safe="")
+
+
+def to_iri(class_name: str, node_id: str) -> str:
+    """Return the canonical entity IRI for a schema class and node ID."""
+    if class_name not in NODE_MODELS:
+        raise ValueError(f"unknown node class: {class_name!r}")
+    return f"{BASE_NAMESPACE}/{_encode_segment(class_name)}/{_encode_segment(node_id)}"
+
+
+def parse_iri(iri: str) -> tuple[str, str]:
+    """Parse an entity IRI produced by ``to_iri`` into ``(class, id)``."""
+    if not isinstance(iri, str) or not iri:
+        raise ValueError("IRI must be a non-empty string")
+
+    parsed = urlparse(iri)
+    base = urlparse(BASE_NAMESPACE)
+    if parsed.scheme != base.scheme or parsed.netloc != base.netloc:
+        raise ValueError(f"IRI {iri!r} is outside {BASE_NAMESPACE}")
+
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) != 2 or parts[0] == PREDICATE_PATH:
+        raise ValueError(f"IRI {iri!r} is not an entity IRI")
+
+    class_name = unquote(parts[0])
+    node_id = unquote(parts[1])
+    if class_name not in NODE_MODELS:
+        raise ValueError(f"unknown node class in IRI: {class_name!r}")
+    return class_name, node_id
+
+
+def predicate_iri(edge_label: str) -> str:
+    """Return the canonical predicate IRI for an ontology edge label."""
+    if edge_label not in EDGE_MODELS:
+        raise ValueError(f"unknown edge label: {edge_label!r}")
+    return f"{BASE_NAMESPACE}/{PREDICATE_PATH}/{_encode_segment(edge_label)}"
+
+
+__all__ = [
+    "BASE_NAMESPACE",
+    "PREDICATE_PATH",
+    "parse_iri",
+    "predicate_iri",
+    "to_iri",
+]

--- a/tests/test_iri.py
+++ b/tests/test_iri.py
@@ -1,0 +1,54 @@
+"""Tests for canonical ontology IRIs."""
+from __future__ import annotations
+
+import unittest
+
+
+class TestOntologyIri(unittest.TestCase):
+    def test_node_iri_round_trips_for_every_node_model(self):
+        from poc_v1.ontology.iri import BASE_NAMESPACE, parse_iri, to_iri
+        from poc_v1.ontology.schema import NODE_MODELS
+
+        self.assertEqual(BASE_NAMESPACE, "https://ontology.subconscious.ai")
+        for class_name in NODE_MODELS:
+            iri = to_iri(class_name, f"{class_name.lower()}_one")
+            self.assertEqual(
+                parse_iri(iri),
+                (class_name, f"{class_name.lower()}_one"),
+            )
+
+    def test_node_iri_is_url_safe_reversible_and_collision_resistant(self):
+        from poc_v1.ontology.iri import parse_iri, to_iri
+
+        first = to_iri("Company", "co_cafe/with spaces")
+        second = to_iri("Company", "co_cafe%2Fwith spaces")
+
+        self.assertNotEqual(first, second)
+        self.assertNotIn(" ", first)
+        self.assertNotIn("/with", first)
+        self.assertEqual(parse_iri(first), ("Company", "co_cafe/with spaces"))
+        self.assertEqual(parse_iri(second), ("Company", "co_cafe%2Fwith spaces"))
+
+    def test_predicate_iri_is_derived_for_every_edge_model(self):
+        from poc_v1.ontology.iri import predicate_iri
+        from poc_v1.ontology.schema import EDGE_MODELS
+
+        iris = {edge: predicate_iri(edge) for edge in EDGE_MODELS}
+
+        self.assertEqual(len(set(iris.values())), len(EDGE_MODELS))
+        self.assertEqual(
+            iris["OFFERED_BY"],
+            "https://ontology.subconscious.ai/predicate/OFFERED_BY",
+        )
+
+    def test_unknown_class_or_edge_raises(self):
+        from poc_v1.ontology.iri import predicate_iri, to_iri
+
+        with self.assertRaises(ValueError):
+            to_iri("NotAClass", "x")
+        with self.assertRaises(ValueError):
+            predicate_iri("NOT_AN_EDGE")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds public poc_v1.ontology.iri module with BASE_NAMESPACE, to_iri, parse_iri, and predicate_iri.
- Derives valid entity classes and predicates from NODE_MODELS / EDGE_MODELS.
- Documents the new consumer import surface in README and CLAUDE.md.

## Validation
- python3 -m unittest discover -s tests -p 'test_iri.py' -v
- bash scripts/agent/validate-fast.sh

Closes #72