### PR TITLE
docs: single-page agent system map

### DIFF
--- a/docs/system-map.html
+++ b/docs/system-map.html
@@ -1,0 +1,510 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>market-ontology System Map</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root, [data-theme="dark"] {
+      --bg:#020617; --grid:#1e293b; --text:#fff; --text-muted:#94a3b8; --text-dim:#475569;
+      --panel:rgba(15,23,42,0.5); --panel-border:#1e293b;
+      --arrow:#64748b; --arrow-emphasis:#34d399; --mask:#0f172a;
+      --frontend-fill:rgba(8,51,68,0.4); --frontend-stroke:#22d3ee;
+      --backend-fill:rgba(6,78,59,0.4); --backend-stroke:#34d399;
+      --database-fill:rgba(76,29,149,0.4); --database-stroke:#a78bfa;
+      --cloud-fill:rgba(120,53,15,0.3); --cloud-stroke:#fbbf24;
+      --security-fill:rgba(136,19,55,0.4); --security-stroke:#fb7185;
+      --messagebus-fill:rgba(251,146,60,0.3); --messagebus-stroke:#fb923c;
+      --external-fill:rgba(30,41,59,0.5); --external-stroke:#94a3b8;
+      --toolbar-bg:rgba(15,23,42,0.8); --toolbar-border:#334155; --toolbar-text:#e2e8f0; --toolbar-hover:rgba(15,23,42,0.95);
+      --code-bg:rgba(15,23,42,0.7);
+    }
+    [data-theme="light"] {
+      --bg:#f8fafc; --grid:#e2e8f0; --text:#0f172a; --text-muted:#64748b; --text-dim:#94a3b8;
+      --panel:#fff; --panel-border:#e2e8f0;
+      --arrow:#94a3b8; --arrow-emphasis:#059669; --mask:#fff;
+      --frontend-fill:rgba(34,211,238,0.15); --frontend-stroke:#0891b2;
+      --backend-fill:rgba(52,211,153,0.18); --backend-stroke:#059669;
+      --database-fill:rgba(167,139,250,0.2); --database-stroke:#7c3aed;
+      --cloud-fill:rgba(251,191,36,0.18); --cloud-stroke:#d97706;
+      --security-fill:rgba(251,113,133,0.15); --security-stroke:#e11d48;
+      --messagebus-fill:rgba(251,146,60,0.15); --messagebus-stroke:#ea580c;
+      --external-fill:rgba(148,163,184,0.18); --external-stroke:#64748b;
+      --toolbar-bg:rgba(255,255,255,0.92); --toolbar-border:#cbd5e1; --toolbar-text:#334155; --toolbar-hover:#fff;
+      --code-bg:#f1f5f9;
+    }
+    * { margin:0; padding:0; box-sizing:border-box; }
+    body {
+      font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace;
+      background:var(--bg); min-height:100vh; padding:2rem; color:var(--text);
+      transition:background .2s ease,color .2s ease; line-height:1.6;
+    }
+    .container { max-width:1340px; margin:0 auto; }
+    .header { margin-bottom:1.5rem; }
+    .header-row { display:flex; align-items:center; gap:1rem; margin-bottom:.5rem; }
+    .pulse-dot { width:12px; height:12px; background:var(--frontend-stroke); border-radius:50%; animation:pulse 2s infinite; }
+    @keyframes pulse { 0%,100%{opacity:1;} 50%{opacity:.5;} }
+    h1 { font-size:1.5rem; font-weight:700; letter-spacing:-.025em; }
+    h2 { font-size:1.1rem; font-weight:700; margin:2.5rem 0 .25rem; letter-spacing:-.02em; }
+    h2 .num { color:var(--frontend-stroke); margin-right:.5rem; }
+    .subtitle { color:var(--text-muted); font-size:.85rem; margin-left:1.75rem; }
+    .lead {
+      color:var(--text-muted); font-size:.8rem; background:var(--panel);
+      border:1px solid var(--panel-border); border-left:3px solid var(--frontend-stroke);
+      border-radius:.5rem; padding:.85rem 1.1rem; margin-top:1rem;
+    }
+    .prose { color:var(--text-muted); font-size:.8rem; margin:.6rem 0; }
+    .prose strong { color:var(--text); font-weight:600; }
+    .prose code, .lead code {
+      background:var(--code-bg); color:var(--text); padding:.05rem .3rem;
+      border-radius:.25rem; font-size:.74rem;
+    }
+    ol.steps, ul.facts { color:var(--text-muted); font-size:.8rem; margin:.6rem 0 .6rem 1.4rem; }
+    ol.steps li, ul.facts li { margin-bottom:.3rem; }
+    ol.steps li strong, ul.facts li strong { color:var(--text); font-weight:600; }
+    .diagram-container {
+      background:var(--panel); border-radius:1rem; border:1px solid var(--panel-border);
+      padding:1.25rem; overflow-x:auto; margin-top:1rem;
+    }
+    svg { width:100%; min-width:min(1000px,100%); display:block; }
+    .footer { text-align:center; margin-top:2.5rem; color:var(--text-dim); font-size:.72rem; }
+    .toolbar { position:fixed; top:1rem; right:1rem; z-index:100; }
+    .toolbar button {
+      background:var(--toolbar-bg); color:var(--toolbar-text); border:1px solid var(--toolbar-border);
+      padding:.5rem .875rem; border-radius:.5rem; font-family:inherit; font-size:.75rem;
+      font-weight:500; cursor:pointer; backdrop-filter:blur(8px); display:inline-flex;
+      align-items:center; gap:.375rem; transition:background .15s,border-color .15s;
+    }
+    .toolbar button:hover { background:var(--toolbar-hover); border-color:var(--arrow); }
+    @media (max-width:720px) {
+      body { padding:1rem; }
+      .toolbar { position:static; display:flex; justify-content:flex-end; margin-bottom:1rem; }
+      .subtitle { margin-left:0; }
+      .diagram-container { padding:.75rem; }
+    }
+    .c-grid { stroke:var(--grid); fill:none; }
+    .c-mask { fill:var(--mask); stroke:none; }
+    .c-frontend { fill:var(--frontend-fill); stroke:var(--frontend-stroke); }
+    .c-backend { fill:var(--backend-fill); stroke:var(--backend-stroke); }
+    .c-database { fill:var(--database-fill); stroke:var(--database-stroke); }
+    .c-cloud { fill:var(--cloud-fill); stroke:var(--cloud-stroke); }
+    .c-security { fill:var(--security-fill); stroke:var(--security-stroke); }
+    .c-messagebus { fill:var(--messagebus-fill); stroke:var(--messagebus-stroke); }
+    .c-external { fill:var(--external-fill); stroke:var(--external-stroke); }
+    .t-primary{fill:var(--text);} .t-muted{fill:var(--text-muted);} .t-dim{fill:var(--text-dim);}
+    .t-frontend{fill:var(--frontend-stroke);} .t-backend{fill:var(--backend-stroke);}
+    .t-database{fill:var(--database-stroke);} .t-cloud{fill:var(--cloud-stroke);}
+    .t-security{fill:var(--security-stroke);} .t-messagebus{fill:var(--messagebus-stroke);}
+    .a-default{stroke:var(--arrow);fill:none;} .a-emphasis{stroke:var(--arrow-emphasis);fill:none;}
+    .a-security{stroke:var(--security-stroke);fill:none;stroke-dasharray:5,5;}
+    .a-dashed{stroke:var(--database-stroke);fill:none;stroke-dasharray:4,4;}
+    .m-default{fill:var(--arrow);} .m-emphasis{fill:var(--arrow-emphasis);}
+    .m-dashed{fill:var(--database-stroke);}
+    .c-region{fill:rgba(251,191,36,0.05);stroke:var(--cloud-stroke);stroke-dasharray:8,4;}
+  </style>
+</head>
+<body>
+  <div class="toolbar">
+    <button id="btn-theme" type="button" title="Toggle theme (T)" aria-label="Toggle theme">
+      <span id="theme-icon" aria-hidden="true">&#9790;</span><span id="theme-label">Dark</span>
+    </button>
+  </div>
+
+  <div class="container">
+    <div class="header">
+      <div class="header-row">
+        <div class="pulse-dot"></div>
+        <h1>market-ontology &mdash; System Map</h1>
+      </div>
+      <p class="subtitle">One page to orient an agent: what the repo is, how data flows through it, and how to change the schema safely.</p>
+    </div>
+
+    <div class="lead">
+      <strong>Reading order for an agent:</strong> the text in each section is authoritative and self-contained
+      &mdash; read it for the facts. The diagram below each section illustrates the same relationships visually.
+      The single source of truth in code is <code>poc_v1/ontology/schema.py</code>
+      (<code>NODE_MODELS</code>, <code>EDGE_MODELS</code>, <code>SCHEMA_VERSION 1.6.0</code>); when this page and the
+      schema disagree, the schema wins. This file is hand-built, not generated &mdash; treat it as a map, not a contract.
+    </div>
+
+    <!-- ================================================================
+         SECTION 1 — ARCHITECTURE
+         ================================================================ -->
+    <h2><span class="num">1</span>Repository architecture</h2>
+    <p class="prose">
+      <strong>market-ontology</strong> is the canonical Pydantic schema for the Subconscious knowledge graph.
+      It is the stable contract every other repo depends on.
+    </p>
+    <ul class="facts">
+      <li><strong>Source of truth</strong> &mdash; <code>poc_v1/ontology/schema.py</code>: 14 node models, 18 edge models, <code>SCHEMA_VERSION 1.6.0</code>. The only definition of graph shape.</li>
+      <li><strong>Public contract</strong> &mdash; four modules under <code>poc_v1.ontology</code> that consumers import directly: <code>schema</code> (the models), <code>graphiti_views</code> (<code>ENTITY_TYPES</code>/<code>EDGE_TYPES</code>/<code>EDGE_TYPE_MAP</code>, <em>derived</em> from schema), <code>identity</code> (company resolver, email/domain&rarr;slug), <code>iri</code> (canonical RDF IRIs).</li>
+      <li><strong>Causal peer</strong> &mdash; <code>causal_dag_v1/</code> holds causal hypotheses (<code>CAUSES</code>, <code>MEDIATES</code>, <code>MODERATES</code>) with NetworkX acyclicity checks. Kept separate: <code>poc_v1</code> is context, <code>causal_dag_v1</code> is result.</li>
+      <li><strong>Generated artifacts</strong> &mdash; <code>scripts/generate_*.py</code> read the schema and write the <code>*.json</code>/<code>*.ttl</code> files under <code>poc_v1/ontology/</code>. Never hand-edit them.</li>
+      <li><strong>Validation</strong> &mdash; <code>scripts/validate_*.py</code> + <code>scripts/agent/</code> check fixtures and generated artifacts; <code>ci.yml</code> and <code>symphony-gate.yml</code> gate <code>main</code>.</li>
+      <li><strong>Consumers</strong> &mdash; spice-harvester, ai-chatbot-native-sizzle, twenty CRM, and the burn-substrate Graphiti sidecar all <code>pip install</code> the package and import the public modules.</li>
+    </ul>
+
+    <div class="diagram-container">
+      <svg viewBox="0 0 1280 800">
+        <defs>
+          <marker id="ah" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" class="m-default"/></marker>
+          <marker id="ah-e" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" class="m-emphasis"/></marker>
+          <marker id="ah-d" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" class="m-dashed"/></marker>
+          <pattern id="grid1" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M 40 0 L 0 0 0 40" class="c-grid" stroke-width="0.5"/></pattern>
+        </defs>
+        <rect width="100%" height="100%" fill="url(#grid1)"/>
+
+        <rect x="40" y="66" width="500" height="312" rx="12" class="c-region" stroke-width="1"/>
+        <text x="54" y="86" class="t-cloud" font-size="10" font-weight="600">poc_v1.ontology &middot; public contract (consumers import these)</text>
+        <rect x="40" y="650" width="800" height="120" rx="12" class="c-region" stroke-width="1"/>
+        <text x="54" y="670" class="t-cloud" font-size="10" font-weight="600">Validation &middot; gates main via GitHub Actions</text>
+        <rect x="880" y="66" width="370" height="540" rx="12" class="c-region" stroke-width="1"/>
+        <text x="894" y="86" class="t-cloud" font-size="10" font-weight="600">Downstream consumers &middot; pip install market-ontology</text>
+
+        <line x1="272" y1="147" x2="297" y2="147" class="a-default" stroke-width="1.5" marker-end="url(#ah)"/>
+        <text x="285" y="141" class="t-muted" font-size="7" text-anchor="middle">derives</text>
+        <line x1="542" y1="147" x2="577" y2="147" class="a-default" stroke-width="1.5" marker-end="url(#ah)"/>
+        <text x="560" y="141" class="t-muted" font-size="7" text-anchor="middle">reads</text>
+        <line x1="710" y1="190" x2="710" y2="235" class="a-default" stroke-width="1.5" marker-end="url(#ah)"/>
+        <text x="726" y="216" class="t-muted" font-size="8">writes</text>
+        <path d="M 540 100 C 620 30, 800 30, 879 100" class="a-emphasis" stroke-width="1.8" marker-end="url(#ah-e)"/>
+        <rect x="648" y="26" width="124" height="15" rx="3" class="c-mask"/>
+        <text x="710" y="37" class="t-backend" font-size="8.5" font-weight="600" text-anchor="middle">pip install &middot; import</text>
+        <line x1="150" y1="622" x2="150" y2="685" class="a-default" stroke-width="1.5" marker-end="url(#ah)"/>
+        <text x="158" y="650" class="t-muted" font-size="7">validate_kg_seed</text>
+        <line x1="340" y1="506" x2="340" y2="685" class="a-default" stroke-width="1.5" marker-end="url(#ah)"/>
+        <text x="348" y="556" class="t-muted" font-size="7">validate_causal_dag</text>
+        <line x1="700" y1="558" x2="672" y2="685" class="a-default" stroke-width="1.5" marker-end="url(#ah)"/>
+        <text x="704" y="624" class="t-muted" font-size="7">generate --check</text>
+        <line x1="420" y1="720" x2="447" y2="720" class="a-default" stroke-width="1.5" marker-end="url(#ah)"/>
+        <text x="434" y="714" class="t-muted" font-size="7" text-anchor="middle">gates</text>
+        <path d="M 840 332 C 872 400, 884 460, 897 511" class="a-dashed" stroke-width="1.4" marker-end="url(#ah-d)"/>
+        <text x="868" y="450" class="t-database" font-size="7" text-anchor="end">super_ego_projection</text>
+
+        <rect x="60" y="104" width="210" height="86" rx="6" class="c-mask"/>
+        <rect x="60" y="104" width="210" height="86" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="165" y="128" class="t-primary" font-size="11" font-weight="700" text-anchor="middle">schema.py</text>
+        <text x="165" y="145" class="t-backend" font-size="8" font-weight="600" text-anchor="middle">&#9656; SOURCE OF TRUTH</text>
+        <text x="165" y="162" class="t-muted" font-size="8.5" text-anchor="middle">NODE_MODELS &times;14 &middot; EDGE_MODELS &times;18</text>
+        <text x="165" y="177" class="t-muted" font-size="8.5" text-anchor="middle">SCHEMA_VERSION 1.6.0</text>
+
+        <rect x="300" y="104" width="210" height="86" rx="6" class="c-mask"/>
+        <rect x="300" y="104" width="210" height="86" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="405" y="128" class="t-primary" font-size="11" font-weight="700" text-anchor="middle">graphiti_views.py</text>
+        <text x="405" y="147" class="t-muted" font-size="8.5" text-anchor="middle">ENTITY_TYPES &middot; EDGE_TYPES</text>
+        <text x="405" y="163" class="t-muted" font-size="8.5" text-anchor="middle">EDGE_TYPE_MAP</text>
+        <text x="405" y="179" class="t-backend" font-size="7.5" text-anchor="middle">derived graphiti-compatible view</text>
+
+        <rect x="60" y="238" width="210" height="86" rx="6" class="c-mask"/>
+        <rect x="60" y="238" width="210" height="86" rx="6" class="c-security" stroke-width="1.5"/>
+        <text x="165" y="262" class="t-primary" font-size="11" font-weight="700" text-anchor="middle">identity.py</text>
+        <text x="165" y="281" class="t-muted" font-size="8.5" text-anchor="middle">CompanyIdentity &middot; to_identity</text>
+        <text x="165" y="297" class="t-muted" font-size="8.5" text-anchor="middle">email / domain / URL &rarr; slug</text>
+        <text x="165" y="313" class="t-security" font-size="7.5" text-anchor="middle">tldextract &middot; PSL-aware resolver</text>
+
+        <rect x="300" y="238" width="210" height="86" rx="6" class="c-mask"/>
+        <rect x="300" y="238" width="210" height="86" rx="6" class="c-frontend" stroke-width="1.5"/>
+        <text x="405" y="262" class="t-primary" font-size="11" font-weight="700" text-anchor="middle">iri.py</text>
+        <text x="405" y="281" class="t-muted" font-size="8.5" text-anchor="middle">to_iri &middot; class_iri &middot; predicate_iri</text>
+        <text x="405" y="297" class="t-muted" font-size="8.5" text-anchor="middle">property_iri &middot; BASE_NAMESPACE</text>
+        <text x="405" y="313" class="t-frontend" font-size="7.5" text-anchor="middle">canonical RDF IRIs &middot; schema-decoupled</text>
+
+        <rect x="40" y="410" width="500" height="96" rx="6" class="c-mask"/>
+        <rect x="40" y="410" width="500" height="96" rx="6" class="c-database" stroke-width="1.5"/>
+        <text x="290" y="436" class="t-primary" font-size="11" font-weight="700" text-anchor="middle">causal_dag_v1 &mdash; causal peer module</text>
+        <text x="290" y="456" class="t-muted" font-size="8.5" text-anchor="middle">nodes.py &middot; edges.py &middot; validate.py (NetworkX acyclicity)</text>
+        <text x="290" y="472" class="t-muted" font-size="8.5" text-anchor="middle">kg_seed/*.jsonl &mdash; the causal layer, kept separate from poc_v1</text>
+        <text x="290" y="491" class="t-database" font-size="7.5" text-anchor="middle">poc_v1 = context (structural edges) &middot; causal_dag_v1 = result (CAUSES / MEDIATES)</text>
+
+        <rect x="40" y="540" width="230" height="82" rx="6" class="c-mask"/>
+        <rect x="40" y="540" width="230" height="82" rx="6" class="c-database" stroke-width="1.5"/>
+        <text x="155" y="566" class="t-primary" font-size="10.5" font-weight="700" text-anchor="middle">poc_v1/kg_seed/*.jsonl</text>
+        <text x="155" y="584" class="t-muted" font-size="8.5" text-anchor="middle">ontology fixtures</text>
+        <text x="155" y="601" class="t-database" font-size="7.5" text-anchor="middle">registered in validate_kg_seed.py::FIXTURES</text>
+
+        <rect x="580" y="104" width="260" height="86" rx="6" class="c-mask"/>
+        <rect x="580" y="104" width="260" height="86" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="710" y="128" class="t-primary" font-size="11" font-weight="700" text-anchor="middle">scripts/generate_*.py</text>
+        <text x="710" y="147" class="t-muted" font-size="8.5" text-anchor="middle">generate_kg_seed_contract</text>
+        <text x="710" y="163" class="t-muted" font-size="8.5" text-anchor="middle">generate_twenty_app</text>
+        <text x="710" y="179" class="t-muted" font-size="8.5" text-anchor="middle">generate_trustgraph_ontology</text>
+
+        <rect x="580" y="238" width="260" height="188" rx="6" class="c-mask"/>
+        <rect x="580" y="238" width="260" height="188" rx="6" class="c-cloud" stroke-width="1.5"/>
+        <text x="710" y="262" class="t-primary" font-size="11" font-weight="700" text-anchor="middle">Generated artifacts</text>
+        <text x="710" y="278" class="t-muted" font-size="8" text-anchor="middle">poc_v1/ontology/ &mdash; *.json + *.ttl</text>
+        <text x="598" y="301" class="t-muted" font-size="8">&bull; node_schemas.json &middot; edge_schemas.json</text>
+        <text x="598" y="317" class="t-muted" font-size="8">&bull; kg_seed_contract.json</text>
+        <text x="598" y="333" class="t-muted" font-size="8">&bull; trustgraph_projection.json / .ttl</text>
+        <text x="598" y="349" class="t-muted" font-size="8">&bull; trustgraph_ontology.json</text>
+        <text x="598" y="365" class="t-muted" font-size="8">&bull; twenty_projection &middot; twenty_app_contract</text>
+        <text x="598" y="381" class="t-muted" font-size="8">&bull; super_ego_projection.json</text>
+        <text x="710" y="406" class="t-cloud" font-size="7.5" text-anchor="middle">regenerated from schema &mdash; never hand-edited</text>
+
+        <rect x="580" y="458" width="260" height="100" rx="6" class="c-mask"/>
+        <rect x="580" y="458" width="260" height="100" rx="6" class="c-cloud" stroke-width="1.5"/>
+        <text x="710" y="482" class="t-primary" font-size="11" font-weight="700" text-anchor="middle">poc_v1/contracts/</text>
+        <text x="710" y="498" class="t-muted" font-size="8" text-anchor="middle">7 JSON-Schema contracts</text>
+        <text x="598" y="519" class="t-muted" font-size="8">&bull; experiment_context / _results &middot; run_mapping</text>
+        <text x="598" y="535" class="t-muted" font-size="8">&bull; causal_dag_projection &middot; normalized_results</text>
+        <text x="598" y="551" class="t-muted" font-size="8">&bull; market_signal &middot; recommendation</text>
+
+        <rect x="60" y="688" width="360" height="64" rx="6" class="c-mask"/>
+        <rect x="60" y="688" width="360" height="64" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="240" y="710" class="t-primary" font-size="10.5" font-weight="700" text-anchor="middle">scripts/validate_*.py &middot; scripts/agent/</text>
+        <text x="240" y="727" class="t-muted" font-size="8" text-anchor="middle">validate_kg_seed &middot; validate_causal_dag &middot; validate_causal_projection</text>
+        <text x="240" y="741" class="t-muted" font-size="8" text-anchor="middle">check-doc-rot.sh &middot; check_accepted_state_spine</text>
+
+        <rect x="450" y="688" width="370" height="64" rx="6" class="c-mask"/>
+        <rect x="450" y="688" width="370" height="64" rx="6" class="c-security" stroke-width="1.5"/>
+        <text x="635" y="710" class="t-primary" font-size="10.5" font-weight="700" text-anchor="middle">GitHub Actions &mdash; CI gate</text>
+        <text x="635" y="727" class="t-muted" font-size="8" text-anchor="middle">ci.yml &middot; symphony-gate.yml &middot; validate-fast.sh</text>
+        <text x="635" y="741" class="t-muted" font-size="8" text-anchor="middle">readiness &middot; preflight &middot; Python 3.11 baseline</text>
+
+        <rect x="900" y="100" width="330" height="92" rx="6" class="c-mask"/>
+        <rect x="900" y="100" width="330" height="92" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="1065" y="124" class="t-primary" font-size="11" font-weight="700" text-anchor="middle">spice-harvester</text>
+        <text x="1065" y="142" class="t-muted" font-size="8.5" text-anchor="middle">research ingest &rarr; source_registry + wiki</text>
+        <text x="1065" y="158" class="t-muted" font-size="8.5" text-anchor="middle">+ typed_graph TTL + kg_seed</text>
+        <text x="1065" y="177" class="t-backend" font-size="8" text-anchor="middle">validates every kg_seed at write time</text>
+
+        <rect x="900" y="210" width="330" height="84" rx="6" class="c-mask"/>
+        <rect x="900" y="210" width="330" height="84" rx="6" class="c-frontend" stroke-width="1.5"/>
+        <text x="1065" y="234" class="t-primary" font-size="11" font-weight="700" text-anchor="middle">ai-chatbot-native-sizzle</text>
+        <text x="1065" y="252" class="t-muted" font-size="8.5" text-anchor="middle">canonical Sizzle graph / evidence UI</text>
+        <text x="1065" y="268" class="t-muted" font-size="8.5" text-anchor="middle">renders /sizzle/&lt;slug&gt;</text>
+        <text x="1065" y="284" class="t-frontend" font-size="8" text-anchor="middle">imports schema for node / edge types</text>
+
+        <rect x="900" y="312" width="330" height="74" rx="6" class="c-mask"/>
+        <rect x="900" y="312" width="330" height="74" rx="6" class="c-cloud" stroke-width="1.5"/>
+        <text x="1065" y="336" class="t-primary" font-size="11" font-weight="700" text-anchor="middle">twenty &mdash; CRM</text>
+        <text x="1065" y="354" class="t-muted" font-size="8.5" text-anchor="middle">consumes twenty_app_contract</text>
+        <text x="1065" y="372" class="t-cloud" font-size="8" text-anchor="middle">company / offering record projection</text>
+
+        <rect x="900" y="404" width="330" height="74" rx="6" class="c-mask"/>
+        <rect x="900" y="404" width="330" height="74" rx="6" class="c-database" stroke-width="1.5"/>
+        <text x="1065" y="428" class="t-primary" font-size="11" font-weight="700" text-anchor="middle">burn-substrate &middot; Graphiti sidecar</text>
+        <text x="1065" y="446" class="t-muted" font-size="8.5" text-anchor="middle">consumes graphiti_views</text>
+        <text x="1065" y="464" class="t-database" font-size="8" text-anchor="middle">ENTITY_TYPES / EDGE_TYPE_MAP</text>
+
+        <rect x="900" y="496" width="330" height="86" rx="6" class="c-mask"/>
+        <rect x="900" y="496" width="330" height="86" rx="6" class="c-messagebus" stroke-width="1.5"/>
+        <text x="1065" y="520" class="t-primary" font-size="11" font-weight="700" text-anchor="middle">SuperEgo / W&amp;B loop</text>
+        <text x="1065" y="538" class="t-muted" font-size="8.5" text-anchor="middle">super_ego_projection &rarr; experiment inputs</text>
+        <text x="1065" y="554" class="t-muted" font-size="8.5" text-anchor="middle">W&amp;B artifacts &rarr; immutable lineage</text>
+        <text x="1065" y="571" class="t-messagebus" font-size="8" text-anchor="middle">Estimate nodes return, linked to ontology IDs</text>
+      </svg>
+    </div>
+
+    <!-- ================================================================
+         SECTION 2 — DATA FLOW
+         ================================================================ -->
+    <h2><span class="num">2</span>How data flows through the system</h2>
+    <p class="prose">
+      The ontology is <strong>context for experiments, not the experiment itself.</strong> Data moves in one
+      direction with a single loop back. The unit that moves is the <strong>(claim, source) pair</strong> &mdash;
+      every fact carries its Evidence.
+    </p>
+    <ol class="steps">
+      <li><strong>Sources</strong> &mdash; a research agent, executive interviews, and web search (Exa / Tavily) produce raw material.</li>
+      <li><strong>Ingest</strong> &mdash; <code>spice-harvester</code> extracts node and edge candidates, each with an <code>Evidence</code> record, into JSONL.</li>
+      <li><strong>Validate</strong> &mdash; Pydantic validates every record against the <code>market-ontology</code> schema <em>at the write boundary</em>. Invalid records are rejected, never written. This is the only place graph shape is enforced.</li>
+      <li><strong>Graph</strong> &mdash; validated records become <code>kg_seed/*.jsonl</code> and a <code>typed_graph</code> RDF projection (IRIs minted by <code>iri.py</code>).</li>
+      <li><strong>Consume</strong> &mdash; UI and CRM consumers read the graph directly.</li>
+      <li><strong>Project to experiments</strong> &mdash; the ontology projects experiment inputs (<code>Transition</code>, <code>StakeholderArchetype</code>, <code>Trait</code>/<code>TraitLevel</code>, <code>Attribute</code>/<code>AttributeLevel</code>) into SuperEgo / W&amp;B via <code>super_ego_projection</code>.</li>
+      <li><strong>Results loop back</strong> &mdash; the DCE engine returns AMCE / WTP results. These become normalized <code>Estimate</code> nodes, linked to the ontology IDs they were computed on via <code>ExperimentRun</code> lineage. <strong>Estimates point at ontology nodes; they never mutate them.</strong></li>
+    </ol>
+
+    <div class="diagram-container">
+      <svg viewBox="0 0 1200 440">
+        <defs>
+          <marker id="ah2" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" class="m-default"/></marker>
+          <marker id="ah2-e" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" class="m-emphasis"/></marker>
+          <marker id="ah2-d" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" class="m-dashed"/></marker>
+          <pattern id="grid2" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M 40 0 L 0 0 0 40" class="c-grid" stroke-width="0.5"/></pattern>
+        </defs>
+        <rect width="100%" height="100%" fill="url(#grid2)"/>
+
+        <line x1="212" y1="198" x2="266" y2="198" class="a-emphasis" stroke-width="1.8" marker-end="url(#ah2-e)"/>
+        <line x1="452" y1="198" x2="506" y2="198" class="a-emphasis" stroke-width="1.8" marker-end="url(#ah2-e)"/>
+        <text x="479" y="192" class="t-muted" font-size="7.5" text-anchor="middle">JSONL candidates</text>
+        <line x1="702" y1="198" x2="756" y2="198" class="a-emphasis" stroke-width="1.8" marker-end="url(#ah2-e)"/>
+        <text x="729" y="192" class="t-muted" font-size="7.5" text-anchor="middle">accepted only</text>
+        <path d="M 932 170 C 965 130, 975 110, 996 96" class="a-default" stroke-width="1.5" marker-end="url(#ah2)"/>
+        <text x="995" y="150" class="t-muted" font-size="7.5" text-anchor="end">graph read</text>
+        <line x1="932" y1="214" x2="996" y2="214" class="a-default" stroke-width="1.5" marker-end="url(#ah2)"/>
+        <text x="964" y="208" class="t-muted" font-size="7.5" text-anchor="middle">project</text>
+        <line x1="1085" y1="266" x2="1085" y2="298" class="a-default" stroke-width="1.5" marker-end="url(#ah2)"/>
+        <text x="1095" y="286" class="t-muted" font-size="7.5">results</text>
+        <path d="M 1000 340 C 900 392, 870 300, 848 250" class="a-dashed" stroke-width="1.5" marker-end="url(#ah2-d)"/>
+        <text x="905" y="388" class="t-database" font-size="7.5">Estimate nodes land back in the graph</text>
+
+        <rect x="40" y="150" width="172" height="96" rx="6" class="c-mask"/>
+        <rect x="40" y="150" width="172" height="96" rx="6" class="c-external" stroke-width="1.5"/>
+        <text x="126" y="178" class="t-primary" font-size="11" font-weight="700" text-anchor="middle">Sources</text>
+        <text x="126" y="197" class="t-muted" font-size="8" text-anchor="middle">research agent</text>
+        <text x="126" y="211" class="t-muted" font-size="8" text-anchor="middle">executive interview</text>
+        <text x="126" y="225" class="t-muted" font-size="8" text-anchor="middle">Exa / Tavily web search</text>
+
+        <rect x="266" y="150" width="186" height="96" rx="6" class="c-mask"/>
+        <rect x="266" y="150" width="186" height="96" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="359" y="178" class="t-primary" font-size="11" font-weight="700" text-anchor="middle">Ingest</text>
+        <text x="359" y="197" class="t-muted" font-size="8" text-anchor="middle">spice-harvester extracts</text>
+        <text x="359" y="211" class="t-muted" font-size="8" text-anchor="middle">node + edge candidates</text>
+        <text x="359" y="225" class="t-backend" font-size="8" text-anchor="middle">each with Evidence &rarr; JSONL</text>
+
+        <rect x="506" y="150" width="196" height="96" rx="6" class="c-mask"/>
+        <rect x="506" y="150" width="196" height="96" rx="6" class="c-security" stroke-width="1.5"/>
+        <text x="604" y="178" class="t-primary" font-size="11" font-weight="700" text-anchor="middle">Validate</text>
+        <text x="604" y="197" class="t-muted" font-size="8" text-anchor="middle">Pydantic write boundary</text>
+        <text x="604" y="211" class="t-muted" font-size="8" text-anchor="middle">market-ontology schema.py</text>
+        <text x="604" y="225" class="t-security" font-size="8" text-anchor="middle">invalid records rejected</text>
+
+        <rect x="756" y="150" width="176" height="96" rx="6" class="c-mask"/>
+        <rect x="756" y="150" width="176" height="96" rx="6" class="c-database" stroke-width="1.5"/>
+        <text x="844" y="178" class="t-primary" font-size="11" font-weight="700" text-anchor="middle">Graph</text>
+        <text x="844" y="197" class="t-muted" font-size="8" text-anchor="middle">kg_seed/*.jsonl</text>
+        <text x="844" y="211" class="t-muted" font-size="8" text-anchor="middle">+ typed_graph RDF (iri.py)</text>
+        <text x="844" y="225" class="t-database" font-size="8" text-anchor="middle">validated nodes + edges</text>
+
+        <rect x="998" y="50" width="172" height="84" rx="6" class="c-mask"/>
+        <rect x="998" y="50" width="172" height="84" rx="6" class="c-frontend" stroke-width="1.5"/>
+        <text x="1084" y="76" class="t-primary" font-size="10.5" font-weight="700" text-anchor="middle">Consumers</text>
+        <text x="1084" y="94" class="t-muted" font-size="8" text-anchor="middle">native-sizzle UI</text>
+        <text x="1084" y="108" class="t-muted" font-size="8" text-anchor="middle">twenty CRM</text>
+        <text x="1084" y="122" class="t-muted" font-size="8" text-anchor="middle">Graphiti sidecar</text>
+
+        <rect x="998" y="170" width="172" height="96" rx="6" class="c-mask"/>
+        <rect x="998" y="170" width="172" height="96" rx="6" class="c-messagebus" stroke-width="1.5"/>
+        <text x="1084" y="196" class="t-primary" font-size="10.5" font-weight="700" text-anchor="middle">SuperEgo / W&amp;B</text>
+        <text x="1084" y="214" class="t-muted" font-size="8" text-anchor="middle">experiment_context +</text>
+        <text x="1084" y="228" class="t-muted" font-size="8" text-anchor="middle">super_ego_projection</text>
+        <text x="1084" y="244" class="t-messagebus" font-size="8" text-anchor="middle">&rarr; DCE engine</text>
+
+        <rect x="998" y="300" width="172" height="84" rx="6" class="c-mask"/>
+        <rect x="998" y="300" width="172" height="84" rx="6" class="c-database" stroke-width="1.5"/>
+        <text x="1084" y="326" class="t-primary" font-size="10.5" font-weight="700" text-anchor="middle">Estimate nodes</text>
+        <text x="1084" y="344" class="t-muted" font-size="8" text-anchor="middle">AMCE / WTP results</text>
+        <text x="1084" y="360" class="t-muted" font-size="8" text-anchor="middle">linked via ExperimentRun</text>
+        <text x="1084" y="374" class="t-database" font-size="8" text-anchor="middle">result, not context</text>
+      </svg>
+    </div>
+
+    <!-- ================================================================
+         SECTION 3 — SCHEMA CHANGE WORKFLOW
+         ================================================================ -->
+    <h2><span class="num">3</span>How to change the schema safely</h2>
+    <p class="prose">
+      A schema change is a <strong>contract change</strong> &mdash; every consumer depends on it. Follow these steps
+      in order. The procedure exists because parallel type systems have been introduced and reverted twice.
+    </p>
+    <ol class="steps">
+      <li><strong>Open an issue</strong> &mdash; state intent, acceptance criteria, and which consumers are affected.</li>
+      <li><strong>Edit <code>schema.py</code></strong> &mdash; change <code>NODE_MODELS</code> / <code>EDGE_MODELS</code> and bump <code>SCHEMA_VERSION</code>.</li>
+      <li><strong>Regenerate artifacts</strong> &mdash; run <code>scripts/generate_*.py</code>. Never hand-edit the generated <code>*.json</code> / <code>*.ttl</code> files; they must match the schema.</li>
+      <li><strong>Add a fixture</strong> &mdash; add or update a <code>kg_seed</code> fixture and register it in <code>scripts/validate_kg_seed.py::FIXTURES</code>.</li>
+      <li><strong>Breaking change?</strong> If the change breaks existing consumers, coordinate them: open <strong>paired PRs</strong> in <code>spice-harvester</code> and <code>ai-chatbot-native-sizzle</code> in the same round, cross-linked. If compatible, skip to step 7.</li>
+      <li><strong>Coordinate consumers</strong> &mdash; land or stage the consumer PRs so nothing reads a shape that no longer exists.</li>
+      <li><strong>Run <code>scripts/agent/validate-fast.sh</code></strong> &mdash; validators plus the full unit suite. Fix everything before pushing. Do not use <code>--no-verify</code>.</li>
+      <li><strong>CI gate &rarr; merge</strong> &mdash; <code>ci.yml</code> and <code>symphony-gate.yml</code> must be green. Then merge.</li>
+    </ol>
+
+    <div class="diagram-container">
+      <svg viewBox="0 0 1200 470">
+        <defs>
+          <marker id="ah3" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" class="m-default"/></marker>
+          <marker id="ah3-s" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" class="m-dashed"/></marker>
+          <pattern id="grid3" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M 40 0 L 0 0 0 40" class="c-grid" stroke-width="0.5"/></pattern>
+        </defs>
+        <rect width="100%" height="100%" fill="url(#grid3)"/>
+
+        <line x1="244" y1="110" x2="288" y2="110" class="a-default" stroke-width="1.5" marker-end="url(#ah3)"/>
+        <line x1="510" y1="110" x2="554" y2="110" class="a-default" stroke-width="1.5" marker-end="url(#ah3)"/>
+        <line x1="776" y1="110" x2="820" y2="110" class="a-default" stroke-width="1.5" marker-end="url(#ah3)"/>
+        <path d="M 940 152 C 940 210, 150 200, 150 286" class="a-default" stroke-width="1.5" marker-end="url(#ah3)"/>
+        <text x="560" y="225" class="t-muted" font-size="7.5" text-anchor="middle">then continue</text>
+        <line x1="262" y1="326" x2="306" y2="326" class="a-security" stroke-width="1.5" marker-end="url(#ah3-s)"/>
+        <text x="284" y="318" class="t-security" font-size="7.5" text-anchor="middle">if breaking</text>
+        <path d="M 200 360 C 320 410, 460 410, 558 348" class="a-default" stroke-width="1.5" marker-end="url(#ah3)"/>
+        <text x="380" y="406" class="t-muted" font-size="7.5" text-anchor="middle">if compatible &mdash; skip</text>
+        <line x1="510" y1="326" x2="554" y2="326" class="a-default" stroke-width="1.5" marker-end="url(#ah3)"/>
+        <line x1="776" y1="326" x2="820" y2="326" class="a-default" stroke-width="1.5" marker-end="url(#ah3)"/>
+
+        <rect x="44" y="78" width="200" height="66" rx="6" class="c-mask"/>
+        <rect x="44" y="78" width="200" height="66" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="144" y="104" class="t-primary" font-size="10.5" font-weight="700" text-anchor="middle">1 &middot; Open issue</text>
+        <text x="144" y="122" class="t-muted" font-size="8" text-anchor="middle">schema change =</text>
+        <text x="144" y="135" class="t-muted" font-size="8" text-anchor="middle">contract change</text>
+
+        <rect x="288" y="78" width="222" height="66" rx="6" class="c-mask"/>
+        <rect x="288" y="78" width="222" height="66" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="399" y="104" class="t-primary" font-size="10.5" font-weight="700" text-anchor="middle">2 &middot; Edit schema.py</text>
+        <text x="399" y="122" class="t-muted" font-size="8" text-anchor="middle">NODE / EDGE_MODELS</text>
+        <text x="399" y="135" class="t-muted" font-size="8" text-anchor="middle">bump SCHEMA_VERSION</text>
+
+        <rect x="554" y="78" width="222" height="66" rx="6" class="c-mask"/>
+        <rect x="554" y="78" width="222" height="66" rx="6" class="c-cloud" stroke-width="1.5"/>
+        <text x="665" y="104" class="t-primary" font-size="10.5" font-weight="700" text-anchor="middle">3 &middot; Regenerate</text>
+        <text x="665" y="122" class="t-muted" font-size="8" text-anchor="middle">scripts/generate_*.py</text>
+        <text x="665" y="135" class="t-muted" font-size="8" text-anchor="middle">never hand-edit output</text>
+
+        <rect x="820" y="78" width="222" height="66" rx="6" class="c-mask"/>
+        <rect x="820" y="78" width="222" height="66" rx="6" class="c-database" stroke-width="1.5"/>
+        <text x="931" y="104" class="t-primary" font-size="10.5" font-weight="700" text-anchor="middle">4 &middot; Add fixture</text>
+        <text x="931" y="122" class="t-muted" font-size="8" text-anchor="middle">register in</text>
+        <text x="931" y="135" class="t-muted" font-size="8" text-anchor="middle">validate_kg_seed::FIXTURES</text>
+
+        <rect x="44" y="294" width="218" height="66" rx="6" class="c-mask"/>
+        <rect x="44" y="294" width="218" height="66" rx="6" class="c-security" stroke-width="1.5"/>
+        <text x="153" y="320" class="t-primary" font-size="10.5" font-weight="700" text-anchor="middle">5 &middot; Breaking change?</text>
+        <text x="153" y="338" class="t-muted" font-size="8" text-anchor="middle">does it break a consumer's</text>
+        <text x="153" y="351" class="t-muted" font-size="8" text-anchor="middle">existing node / edge shape?</text>
+
+        <rect x="306" y="294" width="204" height="66" rx="6" class="c-mask"/>
+        <rect x="306" y="294" width="204" height="66" rx="6" class="c-security" stroke-width="1.5"/>
+        <text x="408" y="320" class="t-primary" font-size="10.5" font-weight="700" text-anchor="middle">6 &middot; Coordinate</text>
+        <text x="408" y="338" class="t-muted" font-size="8" text-anchor="middle">paired PRs &mdash; spice-harvester</text>
+        <text x="408" y="351" class="t-muted" font-size="8" text-anchor="middle">+ native-sizzle, cross-linked</text>
+
+        <rect x="554" y="294" width="222" height="66" rx="6" class="c-mask"/>
+        <rect x="554" y="294" width="222" height="66" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="665" y="320" class="t-primary" font-size="10.5" font-weight="700" text-anchor="middle">7 &middot; validate-fast.sh</text>
+        <text x="665" y="338" class="t-muted" font-size="8" text-anchor="middle">validators + unit suite</text>
+        <text x="665" y="351" class="t-muted" font-size="8" text-anchor="middle">no --no-verify</text>
+
+        <rect x="820" y="294" width="222" height="66" rx="6" class="c-mask"/>
+        <rect x="820" y="294" width="222" height="66" rx="6" class="c-cloud" stroke-width="1.5"/>
+        <text x="931" y="320" class="t-primary" font-size="10.5" font-weight="700" text-anchor="middle">8 &middot; CI gate &rarr; merge</text>
+        <text x="931" y="338" class="t-muted" font-size="8" text-anchor="middle">ci.yml &middot; symphony-gate.yml</text>
+        <text x="931" y="351" class="t-muted" font-size="8" text-anchor="middle">green, then merge</text>
+      </svg>
+    </div>
+
+    <p class="footer">
+      market-ontology system map &bull; hand-built, not generated &bull; authoritative source: poc_v1/ontology/schema.py (SCHEMA_VERSION 1.6.0)
+    </p>
+  </div>
+
+  <script>
+    (function () {
+      var KEY='archify-theme', html=document.documentElement;
+      var btn=document.getElementById('btn-theme'), icon=document.getElementById('theme-icon'), label=document.getElementById('theme-label');
+      function initial(){
+        try { var p=new URLSearchParams(location.search).get('theme'); if(p==='light'||p==='dark') return p; } catch(_){}
+        var s=localStorage.getItem(KEY); if(s==='light'||s==='dark') return s;
+        return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+      }
+      function apply(t){ html.setAttribute('data-theme',t); icon.textContent=t==='dark'?'☾':'☼'; label.textContent=t==='dark'?'Dark':'Light'; }
+      function toggle(){ var n=html.getAttribute('data-theme')==='dark'?'light':'dark'; apply(n); localStorage.setItem(KEY,n); }
+      apply(initial());
+      btn.addEventListener('click', toggle);
+      document.addEventListener('keydown', function(e){
+        if(e.metaKey||e.ctrlKey||e.altKey) return;
+        var t=e.target; if(t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.isContentEditable)) return;
+        if(e.key==='t'||e.key==='T'){ e.preventDefault(); toggle(); }
+      });
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## What
Adds `docs/system-map.html` — one self-contained page combining three diagrams (repository architecture, data flow, schema-change workflow), each paired with an authoritative text section so an agent reading the HTML source gets the semantics, not just SVG geometry.

## Why
Follow-up to #87 (which noted extra diagrams as a separate concern). A single agent-readable orientation page: read the text for facts, the diagram illustrates.

## Risk
Minimal — one new doc file, no code, no schema.

## Test plan
- [x] `scripts/check-doc-rot.sh` green
- [x] Self-contained HTML, dark/light toggle verified
- [ ] CI green

Closes #88